### PR TITLE
A bunch of compilation/run fixes !

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ For now, what you can do is:
 - record and playback inputs
 - dump the audio/video
 
+Note: the game starts up **paused**.
+
 ## Licence
 
 libTAS is distributed under the terms of the GNU General Public License v3.

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,7 @@ do
 done
 
 # Some games do not work if it was not launched inside its folder
-cd ${gamepath%/*}
+cd "${gamepath%/*}"
 
 # Get the list of all shared libraries used by the game
 # Source: http://unix.stackexchange.com/a/101833
@@ -56,7 +56,7 @@ if [ ! -p "$mypipe" ]
 then
     mkfifo $mypipe
 fi
-ldd ./${gamepath##*/} | awk '/=>/{print $(NF-1)}' > $mypipe &
+ldd ./"${gamepath##*/}" | awk '/=>/{print $(NF-1)}' > $mypipe &
 
 while read lib
 do SHLIBS="$SHLIBS -l $lib"
@@ -64,7 +64,7 @@ done < $mypipe
 
 # Launching the game with the libTAS library as LD_PRELOAD
 echo "LD_PRELOAD=$OLDPWD/build/libTAS.so ./${gamepath##*/} $@ &"
-LD_PRELOAD=$OLDPWD/build/libTAS.so ./${gamepath##*/} "$@" &
+LD_PRELOAD=$OLDPWD/build/libTAS.so ./"${gamepath##*/}" "$@" &
 cd - > /dev/null
 sleep 1
 

--- a/src/libTAS/avdumping.cpp
+++ b/src/libTAS/avdumping.cpp
@@ -197,9 +197,9 @@ int openAVDumping(void* window, int video_opengl, char* dumpfile, int sf) {
     /* Initialize swscale context for pixel format conversion */
 
     toYUVctx = sws_getContext(video_frame->width, video_frame->height,  
-                              PIX_FMT_RGBA,
+                              AV_PIX_FMT_RGBA,
                               video_frame->width, video_frame->height, 
-                              PIX_FMT_YUV420P,
+                              AV_PIX_FMT_YUV420P,
                               SWS_LANCZOS | SWS_ACCURATE_RND, NULL,NULL,NULL);
 
     if (toYUVctx == NULL) {

--- a/src/libTAS/dlhook.cpp
+++ b/src/libTAS/dlhook.cpp
@@ -58,11 +58,8 @@ void *my_dlopen(const char *file, int mode, void *dl_caller) {
     dlenter();
     result = dlopen(file, mode);
     dlleave();
-    if (result != NULL) {
-        /* Store the successfully opened library */
-        std::string filestr(file);
-        libraries.push_back(filestr);
-    }
+    if (result)
+        libraries.push_back((file)?file:"");
     return result;
 }
 


### PR DESCRIPTION
I wanted to play a bit with it, so I tried to build it and run it, and I had to fix this couple of things :

* I ran into the "whitespace" issue because Steam's default path for SMB has whitespaces in it :)
* For some reason, [here](https://github.com/clementgallet/libTAS/commit/ecc631ad44152e079d924f1d91cc411e0fd12f22#diff-fcf4ded941634411ebc0d3493fbd5f2cR61), `result` can be *not* null while `file` is null. Constructing a `std::string` from a null pointer is an undefined behaviour.
* `PIX_FMT_YUV420P` and `PIX_FMT_RGBA` must be prefixed with `AV_` since ffmpeg 3.0, and were aliased before. See [here](https://ffmpeg.org/doxygen/2.7/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5) for the 2.7 doxygen (both `AV_x` and `x` do the same thing), and [here](https://ffmpeg.org/doxygen/3.0/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5) for the 3.0's.
* I lost quite a bit of time figuring out the game started paused, so I added this info to the readme.

Now I'll start doing some interesting stuff ;)

