### PR TITLE
Implement thread synchronization and a bunch of stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 
 project(libTAS)
-
+# From here : http://stackoverflow.com/questions/28250081/when-should-i-rerun-cmake
+# Note: We do not recommend using GLOB to collect a list of source files from your source tree.
+# If no CMakeLists.txt file changes when a source is added or removed,
+# then the generated build system cannot know when to ask CMake to regenerate.
 file(GLOB_RECURSE lib_sources src/libTAS/*)
 file(GLOB_RECURSE lin_sources src/linTAS/*)
 file(GLOB shared_sources src/shared/*)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,3 +90,12 @@ else()
     message(WARNING "File IO hooking is disabled")
 endif()
 
+option(ENABLE_CUSTOM_MALLOC "Enable custom Memory Allocation" OFF)
+if (ENABLE_CUSTOM_MALLOC)
+    # Enable custom allocator
+    message(STATUS "Custom memory allocator is enabled")
+    add_definitions(-DLIBTAS_ENABLE_CUSTOM_MALLOC)
+else()
+    message(WARNING "Custom memory allocator is disabled")
+endif()
+

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ rm -f /tmp/libTAS.socket
 
 Usage ()
 {
-    echo "Usage: ./run.sh [options] game_executable_path [game_cmdline_arguments]"
+    echo "Usage: ./run.sh [options] game_executable_relative_path [game_cmdline_arguments]"
     echo "Options are:"
     echo "  -d, --dump FILE     Start a audio/video encode into the specified FILE"
     echo "  -r, --read MOVIE    Play game inputs from MOVIE file"

--- a/src/libTAS/ThreadManager.cpp
+++ b/src/libTAS/ThreadManager.cpp
@@ -1,0 +1,173 @@
+/*
+    Copyright 2015-2016 Clément Gallet <clement.gallet@ens-lyon.org>
+
+    This file is part of libTAS.
+
+    libTAS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libTAS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libTAS.  If not, see <http://www.gnu.org/licenses/>.
+
+    Author : Philippe Virouleau <philippe.virouleau@imag.fr>
+ */
+#include <sstream>
+#include <utility>
+#include <csignal>
+#include "ThreadManager.h"
+
+using namespace std;
+
+
+ThreadManager ThreadManager::instance_ = ThreadManager();
+atomic<int> ThreadManager::spin(0);
+
+ThreadManager::ThreadManager()
+{
+    //FIXME some dirty hardcoded values for SMB
+    //refTable_.insert(71616);
+    //refTable_.insert(222832);
+    //refTable_.insert(282080);
+    //refTable_.insert(140008597117578);
+    //FIXME some dirty hardcoded values for FEZ
+    refTable_.insert(-557);
+
+    // Registering a sighandler enable us to suspend the main thread from any thread !
+    struct sigaction sigusr1;
+    sigemptyset(&sigusr1.sa_mask);
+    sigusr1.sa_flags = 0;
+    sigusr1.sa_handler = ThreadManager::sigspin;
+    int status = sigaction(SIGUSR1, &sigusr1, nullptr);
+    if (status == -1)
+        perror("Error installing signal");
+}
+
+
+void ThreadManager::sigspin(int sig)
+{
+    debuglog(LCF_THREAD, "Waiting, sig = ", sig);
+    while (spin)
+        ;
+}
+
+void ThreadManager::init(pthread_t tid)
+{
+    init_ = true;
+    main_ = tid;
+}
+
+void ThreadManager::suspend(pthread_t from_tid)
+{
+    // We want to suspend main if:
+    //  - from_tid is main (which means it asks for it)
+    //  - from_tid is one of the registered threads we want to wait for
+    if (from_tid == main_ || waitFor(from_tid)) {
+        if (init_) {
+            debuglog(LCF_THREAD, "Suspending main (", stringify(main_), ") because of ", stringify(from_tid));
+            spin = 1;
+            // This doesn't actually kill the thread, it send SIGUSR1 to the main
+            // thread, which make it spins until resume
+            pthread_kill(main_, SIGUSR1);
+        }
+    } else {
+        debuglog(LCF_THREAD, "Not suspending because of ", stringify(from_tid));
+    }
+}
+
+void ThreadManager::start(pthread_t tid, void *from, void *start_routine)
+{
+    if (!init_) {
+        beforeSDL_.insert(start_routine);
+        return;
+    }
+    ptrdiff_t diff = (char *)start_routine - (char *)from;
+    set<pthread_t> &all = threadMap_[diff];
+    all.insert(tid);
+    // Register the current thread id -> routine association
+    // The same tid can be reused with a different routine, but different routines
+    // cannot be running at the same time with the same tid.
+    currentAssociation_[tid] = diff;
+    debuglog(LCF_THREAD, "Register starting ", stringify(tid)," with entrydiff ",  diff, ".");
+    timespec t;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t);
+    //There may be multiple call to start...
+    startTime_[tid].push_back(t);
+}
+
+void ThreadManager::end(pthread_t tid)
+{
+    debuglog(LCF_THREAD, "Register ending ", stringify(tid), ".");
+    timespec t;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t);
+    //There may be multiple call to end...
+    endTime_[tid].push_back(t);
+}
+
+void ThreadManager::resume()
+{
+    if (spin) {
+        spin = 0;
+        debuglog(LCF_THREAD, "Released main.");
+    }
+}
+
+timespec timediff(timespec &start, timespec &end);
+//FIXME pretty this
+timespec timediff(timespec &start, timespec &end)
+{
+    timespec retVal;
+    if ((end.tv_nsec - start.tv_nsec) < 0) {
+        retVal.tv_sec = end.tv_sec - start.tv_sec - 1;
+        retVal.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec;
+    } else {
+        retVal.tv_sec = end.tv_sec - start.tv_sec;
+        retVal.tv_nsec = end.tv_nsec - start.tv_nsec;
+    }
+    return retVal;
+}
+
+bool ThreadManager::waitFor(pthread_t tid)
+{
+    // Lookup the entry point corresponding to this tid, and check if it's
+    // in the reference table
+    ptrdiff_t diff = currentAssociation_[tid];
+    return init_ && refTable_.count(diff);
+}
+
+string ThreadManager::summary()
+{
+    ostringstream oss;
+    for (auto elem : threadMap_) {
+        oss << "\nRecord for entry point : " << elem.first;
+        set<pthread_t> &allThread = elem.second;
+        for (pthread_t t : allThread) {
+            oss << "\n  - " << stringify(t);
+            //FIXME using find would permit to add the const qualifier to this member
+            vector<timespec> &starts = startTime_[t];
+            if (starts.empty())
+                continue;
+            vector<timespec> &ends = endTime_[t];
+            for (unsigned int i = 0; i < starts.size(); i++) {
+                oss << "\n    1: Started";
+                timespec start = starts[i];
+                if (i < ends.size()) {
+                    timespec end = ends[i];
+                    timespec diff = timediff(start, end);
+                    oss << " and lasted " << diff.tv_sec << " seconds and " << diff.tv_nsec << " nsec.";
+                }
+            }
+        }
+    }
+    oss << "\nThese threads started before SDL init and can't be waited for :\n";
+    for (auto elem : beforeSDL_) {
+        oss <<  elem << "\n";
+    }
+    return oss.str();
+}

--- a/src/libTAS/ThreadManager.h
+++ b/src/libTAS/ThreadManager.h
@@ -1,0 +1,78 @@
+/*
+    Copyright 2015-2016 Clément Gallet <clement.gallet@ens-lyon.org>
+
+    This file is part of libTAS.
+
+    libTAS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libTAS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libTAS.  If not, see <http://www.gnu.org/licenses/>.
+
+    Author : Philippe Virouleau <philippe.virouleau@imag.fr>
+ */
+
+#ifndef LIBTAS_THREAD_MANAGER_H
+#define LIBTAS_THREAD_MANAGER_H
+#include "logging.h"
+#include <set>
+#include <map>
+#include <vector>
+#include <string>
+#include <atomic>
+#include <cstddef>
+#include <pthread.h>
+
+
+class ThreadManager {
+    //Private constructor
+    ThreadManager();
+    std::map<pthread_t, std::vector<timespec>> startTime_;
+    std::map<pthread_t, std::vector<timespec>> endTime_;
+    //This will register every pthread created for each start_routine
+    std::map<std::ptrdiff_t, std::set<pthread_t>> threadMap_;
+    std::map<pthread_t, std::ptrdiff_t> currentAssociation_;
+
+    std::set<std::ptrdiff_t> refTable_;
+    std::set<void *> beforeSDL_;
+    bool init_ = false;
+    pthread_t main_ = 0;
+
+    static ThreadManager instance_;
+public:
+    static ThreadManager &get() { return instance_; };
+
+    // Called from SDL_init, assumed to be main thread
+    void init(pthread_t tid);
+    // Register the start of a new thread
+    // It uses the ptrdiff between the start_routine and the calling function
+    // ('from'), which is assumed to be a possible invariant
+    void start(pthread_t tid, void *from, void *start_routine);
+    // Register the end of a thread
+    void end(pthread_t tid);
+    // Should we wait for this entry point ?
+    bool waitFor(pthread_t tid);
+
+    // Attempt to suspend main thread
+    void suspend(pthread_t from_tid);
+    // Resumes main thread
+    void resume();
+
+    pthread_t main() { return main_; };
+    // Display a summary of the current execution (which pthread_t for which entry point)
+    std::string summary();
+
+    // Sig handler for suspending/resuming thread
+    static void sigspin(int sig);
+    static std::atomic<int> spin;
+
+};
+
+#endif

--- a/src/libTAS/hook.cpp
+++ b/src/libTAS/hook.cpp
@@ -20,9 +20,8 @@
 #include "hook.h"
 #include "logging.h"
 #include <string>
-#include "dlhook.h"
 
-bool link_function(void** function, const char* source, const char* library)
+bool link_function(void** function, const char* source, const char* library, const char *version /*= nullptr*/)
 {
     /* Test if function is already linked */
     if (*function != nullptr)
@@ -35,10 +34,14 @@ bool link_function(void** function, const char* source, const char* library)
     /* From this function dl* call will refer to real dl functions */
 
     /* First try to link it from the global namespace */
-    *function = dlsym(RTLD_NEXT, source);
+    if (version)
+        *function = dlvsym(RTLD_NEXT, source, version);
+    else
+        *function = dlsym(RTLD_NEXT, source);
 
     if (*function != nullptr) {
         dlleave();
+        debuglog(LCF_HOOK, "Imported symbol ", source, " function : ", *function);
         return true;
     }
 
@@ -59,6 +62,7 @@ bool link_function(void** function, const char* source, const char* library)
 
                 if (*function != nullptr) {
                     dlleave();
+                    debuglog(LCF_HOOK, "Imported from lib symbol ", source, " function : ", *function);
                     return true;
                 }
             }

--- a/src/libTAS/hook.h
+++ b/src/libTAS/hook.h
@@ -21,6 +21,7 @@
 #define LIBTAS_HOOK_H_INCLUDED
 
 #include "../external/SDL.h"
+#include "dlhook.h"
 
 /* Version of the SDL library */
 extern int SDLver;
@@ -39,10 +40,11 @@ namespace orig {
  * @param[in]  library    substring of the name of the library which contains the function
  * @return                whether we successfully accessed to the function
  */
-bool link_function(void** function, const char* source, const char* library);
+bool link_function(void** function, const char* source, const char* library, const char *version = nullptr);
 
 /* Some macros to make the above function easier to use */
 #define LINK_NAMESPACE(FUNC,LIB) link_function((void**)&orig::FUNC, #FUNC, LIB)
+#define LINK_NAMESPACE_VERSION(FUNC,LIB,V) link_function((void**)&orig::FUNC, #FUNC, LIB, V)
 #define LINK_NAMESPACE_SDL1(FUNC) LINK_NAMESPACE(FUNC,"libSDL-1.2")
 #define LINK_NAMESPACE_SDL2(FUNC) LINK_NAMESPACE(FUNC,"libSDL2-2")
 #define LINK_NAMESPACE_SDLX(FUNC) (SDLver==1)?LINK_NAMESPACE_SDL1(FUNC):LINK_NAMESPACE_SDL2(FUNC)

--- a/src/libTAS/libTAS.cpp
+++ b/src/libTAS/libTAS.cpp
@@ -36,6 +36,7 @@
 #include "../shared/AllInputs.h"
 #include "hook.h"
 #include "inputs/inputs.h"
+#include "ThreadManager.h"
 #ifdef LIBTAS_ENABLE_AVDUMPING
 #include "avdumping.h"
 #endif
@@ -141,7 +142,8 @@ void __attribute__((destructor)) term(void)
 
 /* Override */ void SDL_Init(unsigned int flags){
     debuglog(LCF_SDL, __func__, " call.");
-
+    debuglog(LCF_SDL, "Return addr ", __builtin_return_address(0), ".");
+    ThreadManager::get().init(pthread_self());
     /* Get which sdl version we are using.
      * Stores it in an extern variable.
      */
@@ -247,7 +249,7 @@ void __attribute__((destructor)) term(void)
 
 /* Override */ void SDL_Quit(){
     DEBUGLOGCALL(LCF_SDL);
-
+    debuglog(LCF_THREAD, ThreadManager::get().summary());
 #ifdef LIBTAS_ENABLE_AVDUMPING
     /* SDL 1.2 does not have a destroy window function,
      * because there is only one window,

--- a/src/libTAS/memory/ManagedAllocator.h
+++ b/src/libTAS/memory/ManagedAllocator.h
@@ -14,6 +14,7 @@
 #include <string>
 #include "../logging.h"
 
+#ifdef LIBTAS_ENABLE_CUSTOM_MALLOC
 template<class T>
 class ManagedAllocator
 {
@@ -98,11 +99,13 @@ bool operator!=(const ManagedAllocator<T1>&, const ManagedAllocator<T2>&)
 {
     return false;
 }
+#endif
 
 /*
  * Safe containers, using the regular std containers bare is not allowed.
  */
 namespace safe {
+#ifdef LIBTAS_ENABLE_CUSTOM_MALLOC
     template<class key, class value, class compare = std::less<key>>
         using map = std::map<key, value, compare, ManagedAllocator<std::pair<const key, value>>>;
 
@@ -113,6 +116,18 @@ namespace safe {
         using vector = std::vector<value, ManagedAllocator<value>>;
 
     using string = std::basic_string<char, std::char_traits<char>, ManagedAllocator<char>>;
+#else
+    template<class key, class value, class compare = std::less<key>>
+        using map = std::map<key, value, compare>;
+
+    template<class key, class compare = std::less<key>>
+        using set = std::set<key, compare>;
+
+    template<class value>
+        using vector = std::vector<value>;
+
+    using string = std::basic_string<char, std::char_traits<char>>;
+#endif
 }
 
 #endif

--- a/src/libTAS/memory/MemoryManager.cpp
+++ b/src/libTAS/memory/MemoryManager.cpp
@@ -17,6 +17,7 @@
     along with libTAS.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef LIBTAS_ENABLE_CUSTOM_MALLOC
 #include <unistd.h> // getpagesize()
 #include <cstring>
 #include <cstdint>
@@ -503,4 +504,4 @@ void MemoryManager::dumpAllocationTable()
 }
 
 MemoryManager memorymanager;
-
+#endif

--- a/src/libTAS/memory/MemoryManager.h
+++ b/src/libTAS/memory/MemoryManager.h
@@ -17,6 +17,7 @@
     along with libTAS.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef LIBTAS_ENABLE_CUSTOM_MALLOC
 #ifndef LIBTAS_MEMORYMANAGER_H_INCLUDED
 #define LIBTAS_MEMORYMANAGER_H_INCLUDED
 
@@ -170,5 +171,6 @@ class MemoryManager
 
 extern MemoryManager memorymanager;
 
+#endif
 #endif
 

--- a/src/libTAS/memory/malloc.h
+++ b/src/libTAS/memory/malloc.h
@@ -17,6 +17,7 @@
     along with libTAS.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef LIBTAS_ENABLE_CUSTOM_MALLOC
 #ifndef LIBTAS_MALLOC_H_INCL
 #define LIBTAS_MALLOC_H_INCL
 
@@ -52,5 +53,6 @@ OVERRIDE void *memalign (size_t alignment, size_t size) throw();
 /* Free a block allocated by `malloc', `realloc' or `calloc'.  */
 OVERRIDE void free (void *ptr) throw();
 
+#endif
 #endif
 

--- a/src/libTAS/threads.cpp
+++ b/src/libTAS/threads.cpp
@@ -120,8 +120,9 @@ void *wrapper(void *arg)
     auto go = args->go;
 
 #if 0
+    // NOTE: turn this to '#if 1' to impose de-sync on every single thread
     debuglog(LCF_THREAD, "WAITING for 2 sec");
-    sleep(2);
+    sleep(1);
 #endif
     // Wait for main thread to be ready to sleep
     while (!*go)

--- a/src/linTAS/main.cpp
+++ b/src/linTAS/main.cpp
@@ -117,16 +117,23 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-
+    const int MAX_RETRIES = 3;
+    int retry = 0;
     printf("Connecting to libTAS...\n");
 
-    if (connect(socket_fd, reinterpret_cast<const struct sockaddr*>(&addr), sizeof(struct sockaddr_un)))
-    {
-        printf("Couldn’t connect to socket.\n");
-        return 1;
+    while (connect(socket_fd, reinterpret_cast<const struct sockaddr*>(&addr),
+                   sizeof(struct sockaddr_un))) {
+        printf("Attempt #%i: Couldn’t connect to socket.\n", retry + 1);
+        retry++;
+        if (retry < MAX_RETRIES) {
+            printf("Retrying in 2s");
+            sleep(2);
+        } else {
+            return 1;
+        }
     }
 
-    printf("Connected.\n");
+    printf("Attempt #%i: Connected.\n", retry + 1);
 
     /* Receive informations from the game */
 

--- a/src/shared/Config.cpp
+++ b/src/shared/Config.cpp
@@ -22,7 +22,6 @@
 struct Config config = {
     hud_framecount : true,
     hud_inputs : true,
-    custom_memorymanager : false,
     prevent_savefiles : true
-}; 
+};
 

--- a/src/shared/Config.h
+++ b/src/shared/Config.h
@@ -27,9 +27,6 @@ struct Config {
     /* Display inputs in the HUD */
     bool hud_inputs;
 
-    /* Do we use our custom memory manager for dynamically allocated memory? */
-    bool custom_memorymanager;
-    
     /* Prevent the game to write into savefiles */
     bool prevent_savefiles;
 };


### PR DESCRIPTION
Finally I could take some time to make a proper PR...

Lets start by the bunch of related stuff:
- First commit make custom allocator be a cmake option.
- Last commit fixes a bug that occurs sometimes: if the game does not start fast enough, linTAS would fail to connect; so I implemented a simple try/wait mechanism.

About thread synchronization now.

Here is the few issues we want to address:
1. every single thread is created through pthread_create, we need to be able to differentiate them using a solution which is platform independent.
2. There may be threads we want to wait for (loading ones), and other which we don't care
3. We need a synchronization mechanism that would work for multiple games

## Point 1
The first thing to test when you'll see this PR is 1!
My first try for this was to register the calling address to `SDL_Init`, and use a `ptrdiff` with the entry points given to pthread_create on thread creation, assuming it would be the same regardless of the platform (as I expected both addresses to be in the same non-relocatable binary executable). 
It worked ok for SMB (which is one big executable), but games such as FEZ may not be monolithic.
The loading stuff for FEZ seems to be in a separate library, which means it's relocatable relative to the main binary, and that simply invalidate this first approach.

I managed to get better result by identifying each thread using the [`ptrdiff`](https://github.com/clementgallet/libTAS/compare/master...viroulep:thread_synchro?diff=unified&expand=1&name=thread_synchro#diff-ba945a4680ac9c25a9d0557cab36802fR90) between the routine's address and the caller address.
This approach *will* break if the routine passed to `pthread_create` is not part of the same object file as its caller. Lets just hope you don't want to TAS games like that.

The value identifying each thread should therefore be only dependent on the game executable.
Two different entry points may have the same id only if their caller has the same relative position, which is very unlikely.

So when you checkout this, please activate the `LCF_THREAD` messages in `taskflags.cpp`, and run the 64bit version of FEZ (we should have the same executable).
Just open it, go to the main menu and close it, at the end of the execution you should have a summary of the run looking like this:
>Record for entry point : -557
  - AcwU0i2f
    1: Started
  - Ac2IYj2f
    1: Started
  - Ac5DZj2f
    1: Started
  - AcKsZj2f
    1: Started
  - Act0Zj2f
    1: Started
These threads started before SDL init and can't be waited for :
0x7f68f82745f0
0x7f6907b7bda2
0x7f6907b7ce7f
Game has quit. Exiting

All these number can change but one: you should have "-557" or else we should find another way of identifying threads :s


## Point 2

Tracking every thread creation make it easy to generate a summary as above: I register which entry points have been created under which `pthread_id` (which tells us the number of time a particular entry point has been called).
Playing the game through a couple of level should give a good overview about which entry points are used, and tell us which one we should wait for.
For instance during my test with FEZ, entry point with id 2003 was only started once at the beginning, so it was probably related to automatic save, that doesn't lead to desync during the game (so we don't care).
However -557 was created at every load, which means we do care about it.

Ideally we would detect that automatically, but we could also simply create a simple database for known game executables.

## Point 3

Here is the fun part.
As far as I could test, games create threads and *detach* them at the end of the routine execution, instead of *joining* them.
This is probably because the main thread doesn't want to sleep and want to continue to render frames during loading phases.

So the idea is the following:
1. For every thread creation, get its id
2. If we care about this id (ie: we expect level loading), tell the main thread to sleep and wait for it
3. When a thread is detached, wake up the main thread if it is sleeping.

Here 2 is not straightforward, as we want to pause the main thread from *another* thread: we cannot use pthread's structures like conditions to do that.
I did this through a custom sighandler for `SIGUSR1`.
`pthread_kill` enable us to send to a given `pthread_t` a specific signal, so we register the main thread's `pthread_t`, and we send `SIGUSR1` to it when we want to suspend it.
The custom sighandler is a simple [spin](https://github.com/clementgallet/libTAS/compare/master...viroulep:thread_synchro?diff=unified&expand=1&name=thread_synchro#diff-ba945a4680ac9c25a9d0557cab36802fR53) on an `int`. When [`resume`](https://github.com/clementgallet/libTAS/compare/master...viroulep:thread_synchro?diff=unified&expand=1&name=thread_synchro#diff-ba945a4680ac9c25a9d0557cab36802fR113) is called, the spinning variable is reset, allowing the main thread to resume its execution.


Here is the fez input file I used for this [video](https://www.youtube.com/watch?v=HSMbV7FwWKA): https://we.tl/zekoUXg748 (will disappear in 7 days).
So if the magic number matches, a good test would be to run `./run.sh -r fez.input pat/to/FEZ.bin.x86_64` and see if you can replay this :p (assuming the first save loads the same level obviously).

## Misc

I tried to hook the `pthread_cond` primitives but couldn't do it with the last master for some reasons that I didn't look into. I removed this in 7a08a60ebb847bf47c6124247b768173f4ed42bd, it may give you ideas about what else I tried to track and understand the synchronizations in the game.

I hope I described my approach clearly, please let me know if some points are still obscure.