### PR TITLE
Simplify and speed up savestate loading.

### DIFF
--- a/src/libTAS/checkpoint/SaveState.h
+++ b/src/libTAS/checkpoint/SaveState.h
@@ -23,6 +23,7 @@
 #define LIBTAS_SAVESTATE_H
 
 #include "ProcMapsArea.h"
+#include "StateHeader.h"
 
 namespace libtas {
 class SaveState
@@ -31,24 +32,40 @@ class SaveState
         SaveState(char* pagemappath, char* pagespath, int pagemapfd, int pagesfd);
         ~SaveState();
 
+	// Also resets back to first area
+	void readHeader(StateHeader& sh);
+
+	Area& getArea();
+	void nextArea();
+
+	// Reset back to first area
+	void restart();
+
         char getPageFlag(char* addr);
-        char* getPage(char flag);
-        int getPageFd();
-        void skipPage(char flag);
+	char getNextPageFlag();
+	void queuePageLoad(char* addr);
+	void finishLoad();
 
         explicit operator bool() const {
             return (pmfd != -1);
         }
 
-        char page[4096];
-
     private:
+	char nextFlag();
+
+	char flags[4096];
+	int flag_i;
+	int flags_remaining;
+
         int pmfd, pfd;
 
         Area area;
         char* current_addr;
+	off_t next_pfd_offset;
 
-
+	char* queued_addr;
+	off_t queued_offset;
+	int queued_size;
 };
 }
 


### PR DESCRIPTION
I was disappointed in the speed of savestate loading, so I worked on it and managed to speed it up 6x on my game (from 250 milliseconds to 40).  (With incremental savestates and saving to disk.)

Main improvements:
1) Eliminate huge numbers of page map read() syscalls in SaveState.cpp
2) Eliminate huge numbers of lseek() syscalls in SaveState.cpp
3) Coalesce sequential page reads into a single read() syscall
4) Don't memset() zero pages if we know they're already zero
5) When saving, if our page is the same as the parent page,
   just write out our page instead of loading the parent page and then
   saving it
6) Simplify Checkpoint.cpp readArea() and readAnArea() by using SaveState
   for the main savestate