### PR TITLE
Reset thread-local storage back to the default when a thread function exits.

### DIFF
--- a/src/libTAS/checkpoint/ThreadManager.h
+++ b/src/libTAS/checkpoint/ThreadManager.h
@@ -121,6 +121,14 @@ public:
     static void stopThisThread(int signum);
 
     static void waitForAllRestored(ThreadInfo *thread);
+
+    /* A function called from pthread_start() to fix current_thread
+     * after pthread_start() erases all thread_local variables.
+     */
+    static void setCurrentThread(ThreadInfo *thread) {
+      current_thread = thread;
+    }
+
 };
 }
 


### PR DESCRIPTION
I noticed https://github.com/clementgallet/libTAS/issues/68 and decided to try to make a better fix.  I dove into the glibc source code to find the internal function that sets thread-local storage to its initial defaults, and called it at an appropriate spot.  (I also had to add a couple of other calls to internal libc functions to clean up any old C++ objects or libc state kept in the thread's TLS.)

Warning: I've only tested this code on one game, that worked fine with the previous version as well.  (I don't own a copy of Celeste, and I don't know that I own any games where thread recycling broke.)  Probably you should test to see if it actually fixes Celeste, and maybe test with some more games too.

I did write this little test case, to show that the basic approach works.

```
#include <assert.h>
#include <pthread.h>

#include <iostream>

thread_local int init0;
thread_local int init1 = 1;

struct tls_class {
  int val;

  tls_class() {
    val = 10;
    std::cout << "Constructing tls_class" << std::endl;
  }

  ~tls_class() {
    std::cout << "Destructing tls_class" << std::endl;
  }
};

thread_local tls_class tc;  

void show_tls() {
  int v = tc.val;
  std::cout << init0 << ", " << init1 << ", " << v << std::endl;
}

void set_tls() {
  init0 = 3;
  init1 = 2;
}

extern "C" {
  extern void __call_tls_dtors();
  extern void __libc_thread_freeres();
  extern void _dl_allocate_tls_init(pthread_t pt);
}
void reset_tls() {
  pthread_t me = pthread_self();

  __call_tls_dtors();
  __libc_thread_freeres();
  _dl_allocate_tls_init(me);
}

void* dotest(void *) {
  show_tls();
  set_tls();
  show_tls();
  reset_tls();
  show_tls();
  return nullptr;
}

int main(int argc, char **argv) {
  dotest(nullptr);

  pthread_t pt;
  assert(0 == pthread_create(&pt, NULL, dotest, nullptr));
  pthread_join(pt, nullptr);
}
```