### PR TITLE
Always memset pages that should be zero to zero.

### DIFF
--- a/src/library/checkpoint/Checkpoint.cpp
+++ b/src/library/checkpoint/Checkpoint.cpp
@@ -754,21 +754,7 @@ static void readAnArea(SaveState &saved_state, int spmfd, SaveState &parent_stat
         if (flag == Area::NO_PAGE) {
         }
         else if (flag == Area::ZERO_PAGE) {
-            /* Check if we know the page is already zero,
-               so we can skip the memset. */
-
-	    if (shared_config.incremental_savestates) {
-                /* Gather the flag for the page map */
-                uint64_t page = pagemaps[pagemap_i];
-                bool soft_dirty = page & (0x1ull << 55);
-
-                if (soft_dirty ||
-                parent_state.getPageFlag(curAddr) != Area::ZERO_PAGE) {
-	            memset(static_cast<void*>(curAddr), 0, 4096);
-                }
-
-            }
-
+            memset(static_cast<void*>(curAddr), 0, 4096);
         }
         else if (flag == Area::BASE_PAGE) {
             /* The memory page of the loading savestate is the same as the base


### PR DESCRIPTION
The existing conditions were wrong:

- The deltarune TAS from #117 was not using incremental save states.

- The condition would previously only set pages to zero if they were NOT
  zero in the parent save state, which makes very little sense because
  save states are very rarely loaded from the specific frame where that
  rule would help, and no alternate case was given for any other frame.

Fixes #117. Reverts #111. Partially reverts #98.