### PR TITLE
Allow unattended video encoding.

### DIFF
--- a/src/program/Config.h
+++ b/src/program/Config.h
@@ -61,6 +61,9 @@ public:
     /* Was the dump file modified */
     bool dumpfile_modified;
 
+    /* Were we started up with the -d option? */
+    bool dumping;
+
     /* Path of the libraries used by the game */
     std::string libdir;
 

--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -237,22 +237,33 @@ void GameLoop::start()
         processInputs(ai);
         prev_ai = ai;
 
+        bool shouldQuit = false;
+
         /* Pause if needed */
         if ((context->pause_frame == (context->framecount + 1)) ||
             ((context->config.sc.recording != SharedConfig::NO_RECORDING) &&
             ((context->config.sc.movie_framecount + context->pause_frame) == (context->framecount + 1)))) {
 
-            /* Disable pause */
-            context->pause_frame = 0;
+            if (context->config.dumping) {
+                /* If we're dumping from the command line, we are done */
+                shouldQuit = true;
+            } else {
+                /* Disable pause */
+                context->pause_frame = 0;
 
-            /* Pause and disable fast-forward */
-            context->config.sc.running = false;
-            context->config.sc.fastforward = false;
-            context->config.sc_modified = true;
-            emit sharedConfigChanged();
+                /* Pause and disable fast-forward */
+                context->config.sc.running = false;
+                context->config.sc.fastforward = false;
+                context->config.sc_modified = true;
+                emit sharedConfigChanged();
+            }
         }
 
         endFrameMessages(ai);
+
+        if (shouldQuit) {
+            context->status = Context::QUITTING;
+        }
 
     }
 }
@@ -454,6 +465,10 @@ bool GameLoop::startFrameMessages()
             emit fpsChanged(fps, lfps);
             break;
         case MSGB_QUIT:
+            if (context->config.dumping) {
+                /* Finished running a dump from the command line */
+                exit(0);
+            }
             return true;
         default:
             std::cerr << "Got unknown message!!!" << std::endl;

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <iostream>
 #include <fcntl.h>
+#include <getopt.h>
 
 
 #define SOCKET_FILENAME "/tmp/libTAS.socket"
@@ -65,9 +66,19 @@ int main(int argc, char **argv)
     char* abspath;
     std::ofstream o;
     std::string moviefile;
-    
+
+    static struct option long_options[] =
+    {
+        {"read", required_argument, nullptr, 'r'},
+        {"write", required_argument, nullptr, 'w'},
+        {"dump", required_argument, nullptr, 'd'},
+        {"help", no_argument, nullptr, 'h'},
+        {nullptr, 0, nullptr, 0}
+    };
+    int option_index = 0;
+
     // std::string libname;
-    while ((c = getopt (argc, argv, "+r:w:d:h")) != -1) {
+    while ((c = getopt_long (argc, argv, "+r:w:d:h", long_options, &option_index)) != -1) {
         switch (c) {
             case 'r':
             case 'w':

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -102,8 +102,8 @@ int main(int argc, char **argv)
 
                 abspath = realpath(optarg, buf);
                 if (abspath) {
-                    context.config.sc.av_dumping = true;
                     context.config.dumpfile = abspath;
+                    context.config.dumping = true;
                 }
                 break;
             case '?':

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -303,6 +303,14 @@ MainWindow::MainWindow(Context* c) : QMainWindow(), context(c)
     setCentralWidget(centralWidget);
 
     updateUIFromConfig();
+
+    /* We are dumping from the command line */
+    if (context->config.dumping) {
+        slotToggleEncode();
+        slotPause(false);
+	slotFastForward(true);
+        slotLaunch();
+    }
 }
 
 MainWindow::~MainWindow()
@@ -1332,7 +1340,7 @@ void MainWindow::slotToggleEncode()
     /* Prompt a confirmation message for overwriting an encode file */
     if (!context->config.sc.av_dumping) {
         struct stat sb;
-        if (stat(context->config.dumpfile.c_str(), &sb) == 0) {
+        if (stat(context->config.dumpfile.c_str(), &sb) == 0 && sb.st_size != 0) {
             /* Pause the game during the choice */
             context->config.sc.running = false;
             context->config.sc_modified = true;


### PR DESCRIPTION
Automatically encode the movie and then exit if `-d` or `--dump` is passed as an argument. Don't ask for confirmation when overwriting a video file if it is completely empty.

Closes #122.