### PR TITLE
Send save files for GameMaker games into a temporary directory.

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -117,6 +117,8 @@ void GameLoop::launchGameThread()
     else
         unsetenv("LP_PERF");
 
+    setenv("LIBTAS_START_FRAME", std::to_string(context->framecount).c_str(), 1);
+
     /* Disable Address Space Layout Randomization for the game, so that ram
      * watch addresses do not change on game restart.
      * Source: https://stackoverflow.com/questions/5194666/disable-randomization-of-memory-addresses/30385370#30385370

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -156,10 +156,10 @@ MainWindow::MainWindow(Context* c) : QMainWindow(), context(c)
 
     /* Initial time */
     initialTimeSec = new QSpinBox();
-    initialTimeSec->setMaximum(1000000000);
+    initialTimeSec->setMaximum(2147483647);
     initialTimeSec->setMinimumWidth(50);
     initialTimeNsec = new QSpinBox();
-    initialTimeNsec->setMaximum(1000000000);
+    initialTimeNsec->setMaximum(999999999);
     initialTimeNsec->setMinimumWidth(50);
     disabledWidgetsOnStart.append(initialTimeSec);
     disabledWidgetsOnStart.append(initialTimeNsec);


### PR DESCRIPTION
GameMaker games are hardcoded to save data to `$HOME/.config/GAMETITLE`, so this will redirect save files for Undertale into a temporary folder based on the `libTAS` program's process ID.

(This is probably not a good idea to merge as-is, but I wanted the code to be visible somewhere you'd see it.)

See: #87