### PR TITLE
Implement and extend various hooks used by a unity game

### DIFF
--- a/src/library/steam/steamapiinternal.h
+++ b/src/library/steam/steamapiinternal.h
@@ -22,6 +22,7 @@
 namespace libtas {
 
 OVERRIDE HSteamUser SteamAPI_GetHSteamUser();
+OVERRIDE HSteamPipe SteamAPI_GetHSteamPipe();
 OVERRIDE void * SteamInternal_ContextInit( void *pContextInitData );
 OVERRIDE void * SteamInternal_CreateInterface( const char *ver );
 

--- a/src/library/xevents.cpp
+++ b/src/library/xevents.cpp
@@ -215,7 +215,7 @@ int XPending(Display *display)
     return ret;
 }
 
-Bool XCheckIfEvent(Display *display, XEvent *event_return, Bool (*predicate)(), XPointer arg)
+Bool XCheckIfEvent(Display *display, XEvent *event_return, Bool (*predicate)(Display *, XEvent *, XPointer), XPointer arg)
 {
     LINK_NAMESPACE_GLOBAL(XCheckIfEvent);
     if (GlobalState::isNative()) {

--- a/src/library/xevents.h
+++ b/src/library/xevents.h
@@ -36,7 +36,7 @@ OVERRIDE Bool XCheckTypedEvent(Display *display, int event_type, XEvent *event_r
 OVERRIDE Bool XCheckTypedWindowEvent(Display *display, Window w, int event_type, XEvent *event_return);
 OVERRIDE int XEventsQueued(Display* display, int mode);
 OVERRIDE int XPending(Display *display);
-OVERRIDE Bool XCheckIfEvent(Display *display, XEvent *event_return, Bool (*predicate)(), XPointer arg);
+OVERRIDE Bool XCheckIfEvent(Display *display, XEvent *event_return, Bool (*predicate)(Display *, XEvent *, XPointer), XPointer arg);
 OVERRIDE Status XSendEvent(Display *display, Window w, Bool propagate, long event_mask, XEvent *event_send);
 
 }

--- a/src/library/xrandr.cpp
+++ b/src/library/xrandr.cpp
@@ -38,6 +38,13 @@ OVERRIDE XRRCrtcInfo *XRRGetCrtcInfo (Display *dpy, XRRScreenResources *resource
         /* Change the settings. */
         crtcInfo->width = shared_config.screen_width;
         crtcInfo->height = shared_config.screen_height;
+        for (int i = 0; i < resources->nmode; i++) {
+            if (resources->modes[i].width == shared_config.screen_width &&
+                resources->modes[i].height == shared_config.screen_height) {
+                crtcInfo->mode = i;
+                break;
+            }
+        }
     }
 
     return crtcInfo;


### PR DESCRIPTION
XCheckIfEvent: Fixed compiler error about the definition not matching the original.
XRRGetCrtcInfo: Code was ignoring width and height and using the mode width and height instead.
XQueryPointer: Not setting root_return was causing an infinite loop in code that used it.
SteamAPI_GetHSteamUser/SteamAPI_GetHSteamPipe: Return dummy handles when virtual steam is enabled so it doesn't look like the functions are failing.
SteamInternal_CreateInterface: Quick hack of extracting a symbol from the argument and delegating to that hook.