### PR TITLE
Fix inconsistent library naming

### DIFF
--- a/src/library/ScreenCapture.cpp
+++ b/src/library/ScreenCapture.cpp
@@ -162,12 +162,12 @@ void ScreenCapture::initScreenSurface()
     /* Set up a backup surface/framebuffer */
     if (game_info.video & GameInfo::OPENGL) {
         /* Generate FBO and RBO */
-        LINK_NAMESPACE(glGenFramebuffers, "libGL");
-        LINK_NAMESPACE(glBindFramebuffer, "libGL");
-        LINK_NAMESPACE(glGenRenderbuffers, "libGL");
-        LINK_NAMESPACE(glBindRenderbuffer, "libGL");
-        LINK_NAMESPACE(glRenderbufferStorage, "libGL");
-        LINK_NAMESPACE(glFramebufferRenderbuffer, "libGL");
+        LINK_NAMESPACE(glGenFramebuffers, "GL");
+        LINK_NAMESPACE(glBindFramebuffer, "GL");
+        LINK_NAMESPACE(glGenRenderbuffers, "GL");
+        LINK_NAMESPACE(glBindRenderbuffer, "GL");
+        LINK_NAMESPACE(glRenderbufferStorage, "GL");
+        LINK_NAMESPACE(glFramebufferRenderbuffer, "GL");
 
         if (screenFBO == 0) {
             orig::glGenFramebuffers(1, &screenFBO);
@@ -233,12 +233,12 @@ void ScreenCapture::destroyScreenSurface()
 {
     /* Delete openGL framebuffers */
     if (screenFBO != 0) {
-        LINK_NAMESPACE(glDeleteFramebuffers, "libGL");
+        LINK_NAMESPACE(glDeleteFramebuffers, "GL");
         orig::glDeleteFramebuffers(1, &screenFBO);
         screenFBO = 0;
     }
     if (screenRBO != 0) {
-        LINK_NAMESPACE(glDeleteRenderbuffers, "libGL");
+        LINK_NAMESPACE(glDeleteRenderbuffers, "GL");
         orig::glDeleteRenderbuffers(1, &screenRBO);
         screenRBO = 0;
     }
@@ -363,9 +363,9 @@ int ScreenCapture::getPixels(uint8_t **pixels, bool draw)
         return size;
 
     if (game_info.video & GameInfo::OPENGL) {
-        LINK_NAMESPACE(glReadPixels, "libGL");
-        LINK_NAMESPACE(glBindFramebuffer, "libGL");
-        LINK_NAMESPACE(glBlitFramebuffer, "libGL");
+        LINK_NAMESPACE(glReadPixels, "GL");
+        LINK_NAMESPACE(glBindFramebuffer, "GL");
+        LINK_NAMESPACE(glBlitFramebuffer, "GL");
 
         /* Copy the default framebuffer to our FBO */
         orig::glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
@@ -458,8 +458,8 @@ int ScreenCapture::setPixels() {
         return 0;
 
     if (game_info.video & GameInfo::OPENGL) {
-        LINK_NAMESPACE(glBindFramebuffer, "libGL");
-        LINK_NAMESPACE(glBlitFramebuffer, "libGL");
+        LINK_NAMESPACE(glBindFramebuffer, "GL");
+        LINK_NAMESPACE(glBlitFramebuffer, "GL");
 
         orig::glBindFramebuffer(GL_READ_FRAMEBUFFER, screenFBO);
         orig::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);

--- a/src/library/audio/alsa/pcm.cpp
+++ b/src/library/audio/alsa/pcm.cpp
@@ -87,7 +87,7 @@ static int get_latency();
 int snd_pcm_open(snd_pcm_t **pcm, const char *name, snd_pcm_stream_t stream, int mode)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_open, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_open);
         return orig::snd_pcm_open(pcm, name, stream, mode);
     }
 
@@ -121,7 +121,7 @@ int snd_pcm_open(snd_pcm_t **pcm, const char *name, snd_pcm_stream_t stream, int
 int snd_pcm_close(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_close, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_close);
         return orig::snd_pcm_close(pcm);
     }
 
@@ -132,7 +132,7 @@ int snd_pcm_close(snd_pcm_t *pcm)
 int snd_pcm_nonblock(snd_pcm_t *pcm, int nonblock)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_nonblock, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_nonblock);
         return orig::snd_pcm_nonblock(pcm, nonblock);
     }
 
@@ -143,7 +143,7 @@ int snd_pcm_nonblock(snd_pcm_t *pcm, int nonblock)
 int snd_pcm_start(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_start, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_start);
         return orig::snd_pcm_start(pcm);
     }
 
@@ -156,7 +156,7 @@ int snd_pcm_start(snd_pcm_t *pcm)
 int snd_pcm_resume(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_resume, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_resume);
         return orig::snd_pcm_resume(pcm);
     }
 
@@ -169,7 +169,7 @@ int snd_pcm_resume(snd_pcm_t *pcm)
 int snd_pcm_wait(snd_pcm_t *pcm, int timeout)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_wait, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_wait);
         return orig::snd_pcm_wait(pcm, timeout);
     }
     debuglog(LCF_SOUND, __func__, " called with timeout ", timeout);
@@ -198,7 +198,7 @@ int snd_pcm_wait(snd_pcm_t *pcm, int timeout)
 int snd_pcm_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_delay, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_delay);
         return orig::snd_pcm_delay(pcm, delayp);
     }
 
@@ -211,7 +211,7 @@ int snd_pcm_delay(snd_pcm_t *pcm, snd_pcm_sframes_t *delayp)
 snd_pcm_sframes_t snd_pcm_avail_update(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_avail_update, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_avail_update);
         return orig::snd_pcm_avail_update(pcm);
     }
 
@@ -226,7 +226,7 @@ snd_pcm_sframes_t snd_pcm_avail_update(snd_pcm_t *pcm)
 int snd_pcm_hw_params(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params);
         return orig::snd_pcm_hw_params(pcm, params);
     }
 
@@ -246,7 +246,7 @@ int snd_pcm_hw_params(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 int snd_pcm_sw_params_current(snd_pcm_t *pcm, snd_pcm_sw_params_t *params)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_sw_params_current, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_sw_params_current);
         return orig::snd_pcm_sw_params_current(pcm, params);
     }
 
@@ -257,7 +257,7 @@ int snd_pcm_sw_params_current(snd_pcm_t *pcm, snd_pcm_sw_params_t *params)
 int snd_pcm_sw_params(snd_pcm_t *pcm, snd_pcm_sw_params_t *params)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_sw_params, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_sw_params);
         return orig::snd_pcm_sw_params(pcm, params);
     }
 
@@ -277,7 +277,7 @@ int snd_pcm_sw_params(snd_pcm_t *pcm, snd_pcm_sw_params_t *params)
 int snd_pcm_prepare(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_prepare, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_prepare);
         return orig::snd_pcm_prepare(pcm);
     }
 
@@ -295,7 +295,7 @@ static int get_latency()
 snd_pcm_sframes_t snd_pcm_writei(snd_pcm_t *pcm, const void *buffer, snd_pcm_uframes_t size)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_writei, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_writei);
         return orig::snd_pcm_writei(pcm, buffer, size);
     }
 
@@ -353,7 +353,7 @@ snd_pcm_sframes_t snd_pcm_writei(snd_pcm_t *pcm, const void *buffer, snd_pcm_ufr
 snd_pcm_sframes_t snd_pcm_readi(snd_pcm_t *pcm, void *buffer, snd_pcm_uframes_t size)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_readi, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_readi);
         return orig::snd_pcm_readi(pcm, buffer, size);
     }
 
@@ -364,7 +364,7 @@ snd_pcm_sframes_t snd_pcm_readi(snd_pcm_t *pcm, void *buffer, snd_pcm_uframes_t 
 int snd_pcm_mmap_begin(snd_pcm_t *pcm, const snd_pcm_channel_area_t **areas, snd_pcm_uframes_t *offset, snd_pcm_uframes_t *frames)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_mmap_begin, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_mmap_begin);
         return orig::snd_pcm_mmap_begin(pcm, areas, offset, frames);
     }
 
@@ -438,7 +438,7 @@ int snd_pcm_mmap_begin(snd_pcm_t *pcm, const snd_pcm_channel_area_t **areas, snd
 snd_pcm_sframes_t snd_pcm_mmap_commit(snd_pcm_t *pcm, snd_pcm_uframes_t offset, snd_pcm_uframes_t frames)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_mmap_commit, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_mmap_commit);
         return orig::snd_pcm_mmap_commit(pcm, offset, frames);
     }
 
@@ -453,7 +453,7 @@ snd_pcm_sframes_t snd_pcm_mmap_commit(snd_pcm_t *pcm, snd_pcm_uframes_t offset, 
 int snd_pcm_hw_params_any(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_any, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_any);
         return orig::snd_pcm_hw_params_any(pcm, params);
     }
 
@@ -464,7 +464,7 @@ int snd_pcm_hw_params_any(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 size_t snd_pcm_hw_params_sizeof(void)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_sizeof, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_sizeof);
         return orig::snd_pcm_hw_params_sizeof();
     }
 
@@ -475,7 +475,7 @@ size_t snd_pcm_hw_params_sizeof(void)
 int snd_pcm_hw_params_malloc(snd_pcm_hw_params_t **ptr)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_malloc, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_malloc);
         return orig::snd_pcm_hw_params_malloc(ptr);
     }
 
@@ -487,7 +487,7 @@ int snd_pcm_hw_params_malloc(snd_pcm_hw_params_t **ptr)
 void snd_pcm_hw_params_free(snd_pcm_hw_params_t *obj)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_free, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_free);
         return orig::snd_pcm_hw_params_free(obj);
     }
 
@@ -497,7 +497,7 @@ void snd_pcm_hw_params_free(snd_pcm_hw_params_t *obj)
 void snd_pcm_hw_params_copy(snd_pcm_hw_params_t *dst, const snd_pcm_hw_params_t *src)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_copy, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_copy);
         return orig::snd_pcm_hw_params_copy(dst, src);
     }
 
@@ -507,7 +507,7 @@ void snd_pcm_hw_params_copy(snd_pcm_hw_params_t *dst, const snd_pcm_hw_params_t 
 int snd_pcm_hw_params_set_access(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_access_t access)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_access, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_access);
         return orig::snd_pcm_hw_params_set_access(pcm, params, access);
     }
 
@@ -521,7 +521,7 @@ int snd_pcm_hw_params_set_access(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, sn
 int snd_pcm_hw_params_set_format(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_format_t val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_format, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_format);
         return orig::snd_pcm_hw_params_set_format(pcm, params, val);
     }
 
@@ -553,7 +553,7 @@ int snd_pcm_hw_params_set_format(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, sn
 int snd_pcm_hw_params_get_channels(const snd_pcm_hw_params_t *params, unsigned int *val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_channels, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_channels);
         return orig::snd_pcm_hw_params_get_channels(params, val);
     }
 
@@ -568,7 +568,7 @@ int snd_pcm_hw_params_get_channels(const snd_pcm_hw_params_t *params, unsigned i
 int snd_pcm_hw_params_get_channels_max(const snd_pcm_hw_params_t *params, unsigned int *val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_channels_max, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_channels_max);
         return orig::snd_pcm_hw_params_get_channels_max(params, val);
     }
 
@@ -581,7 +581,7 @@ int snd_pcm_hw_params_get_channels_max(const snd_pcm_hw_params_t *params, unsign
 int snd_pcm_hw_params_set_channels(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_channels, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_channels);
         return orig::snd_pcm_hw_params_set_channels(pcm, params, val);
     }
 
@@ -596,7 +596,7 @@ int snd_pcm_hw_params_set_channels(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, 
 int snd_pcm_hw_params_set_rate(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val, int dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_rate, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_rate);
         return orig::snd_pcm_hw_params_set_rate(pcm, params, val, dir);
     }
 
@@ -611,7 +611,7 @@ int snd_pcm_hw_params_set_rate(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsi
 int snd_pcm_hw_params_set_rate_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_rate_near, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_rate_near);
         return orig::snd_pcm_hw_params_set_rate_near(pcm, params, val, dir);
     }
 
@@ -626,7 +626,7 @@ int snd_pcm_hw_params_set_rate_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params,
 int snd_pcm_hw_params_set_rate_resample(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_rate_resample, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_rate_resample);
         return orig::snd_pcm_hw_params_set_rate_resample(pcm, params, val);
     }
 
@@ -641,7 +641,7 @@ static int periods = 2;
 int snd_pcm_hw_params_get_period_size(const snd_pcm_hw_params_t *params, snd_pcm_uframes_t *frames, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_period_size, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_period_size);
         return orig::snd_pcm_hw_params_get_period_size(params, frames, dir);
     }
 
@@ -654,7 +654,7 @@ int snd_pcm_hw_params_get_period_size(const snd_pcm_hw_params_t *params, snd_pcm
 int snd_pcm_hw_params_get_period_time_min(const snd_pcm_hw_params_t *params, unsigned int *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_period_time_min, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_period_time_min);
         return orig::snd_pcm_hw_params_get_period_time_min(params, val, dir);
     }
 
@@ -667,7 +667,7 @@ int snd_pcm_hw_params_get_period_time_min(const snd_pcm_hw_params_t *params, uns
 int snd_pcm_hw_params_set_period_size_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_uframes_t *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_period_size_near, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_period_size_near);
         return orig::snd_pcm_hw_params_set_period_size_near(pcm, params, val, dir);
     }
 
@@ -678,7 +678,7 @@ int snd_pcm_hw_params_set_period_size_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *
 int snd_pcm_hw_params_set_periods_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_periods_near, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_periods_near);
         return orig::snd_pcm_hw_params_set_periods_near(pcm, params, val, dir);
     }
 
@@ -690,7 +690,7 @@ int snd_pcm_hw_params_set_periods_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *para
 int snd_pcm_hw_params_get_buffer_size(const snd_pcm_hw_params_t *params, snd_pcm_uframes_t *val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_buffer_size, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_buffer_size);
         return orig::snd_pcm_hw_params_get_buffer_size(params, val);
     }
 
@@ -702,7 +702,7 @@ int snd_pcm_hw_params_get_buffer_size(const snd_pcm_hw_params_t *params, snd_pcm
 int snd_pcm_hw_params_get_buffer_time_max(const snd_pcm_hw_params_t *params, unsigned int *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_get_buffer_time_max, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_get_buffer_time_max);
         return orig::snd_pcm_hw_params_get_buffer_time_max(params, val, dir);
     }
 
@@ -717,7 +717,7 @@ int snd_pcm_hw_params_get_buffer_time_max(const snd_pcm_hw_params_t *params, uns
 int snd_pcm_hw_params_set_buffer_size_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, snd_pcm_uframes_t *val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_buffer_size_near, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_buffer_size_near);
         return orig::snd_pcm_hw_params_set_buffer_size_near(pcm, params, val);
     }
 
@@ -729,7 +729,7 @@ int snd_pcm_hw_params_set_buffer_size_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *
 int snd_pcm_hw_params_set_buffer_time_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int *val, int *dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_set_buffer_time_near, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_set_buffer_time_near);
         return orig::snd_pcm_hw_params_set_buffer_time_near(pcm, params, val, dir);
     }
 
@@ -752,7 +752,7 @@ int snd_pcm_hw_params_set_buffer_time_near(snd_pcm_t *pcm, snd_pcm_hw_params_t *
 int snd_pcm_hw_params_test_rate(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, unsigned int val, int dir)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_hw_params_test_rate, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_hw_params_test_rate);
         return orig::snd_pcm_hw_params_test_rate(pcm, params, val, dir);
     }
 
@@ -763,7 +763,7 @@ int snd_pcm_hw_params_test_rate(snd_pcm_t *pcm, snd_pcm_hw_params_t *params, uns
 size_t snd_pcm_sw_params_sizeof(void)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_sw_params_sizeof, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_sw_params_sizeof);
         return orig::snd_pcm_sw_params_sizeof();
     }
 
@@ -775,7 +775,7 @@ size_t snd_pcm_sw_params_sizeof(void)
 int snd_pcm_sw_params_set_start_threshold(snd_pcm_t *pcm, snd_pcm_sw_params_t *params, snd_pcm_uframes_t val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_sw_params_set_start_threshold, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_sw_params_set_start_threshold);
         return orig::snd_pcm_sw_params_set_start_threshold(pcm, params, val);
     }
 
@@ -786,7 +786,7 @@ int snd_pcm_sw_params_set_start_threshold(snd_pcm_t *pcm, snd_pcm_sw_params_t *p
 int snd_pcm_sw_params_set_avail_min(snd_pcm_t *pcm, snd_pcm_sw_params_t *params, snd_pcm_uframes_t val)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_sw_params_set_avail_min, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_sw_params_set_avail_min);
         return orig::snd_pcm_sw_params_set_avail_min(pcm, params, val);
     }
 
@@ -797,7 +797,7 @@ int snd_pcm_sw_params_set_avail_min(snd_pcm_t *pcm, snd_pcm_sw_params_t *params,
 snd_pcm_chmap_t *snd_pcm_get_chmap(snd_pcm_t *pcm)
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(snd_pcm_get_chmap, nullptr);
+        LINK_NAMESPACE_GLOBAL(snd_pcm_get_chmap);
         return orig::snd_pcm_get_chmap(pcm);
     }
 

--- a/src/library/audio/fluidsynth/fluidsynth.cpp
+++ b/src/library/audio/fluidsynth/fluidsynth.cpp
@@ -39,7 +39,7 @@ int fluid_settings_getstr_default(fluid_settings_t *settings, const char *name, 
         return 0; // FLUID_OK
     }
 
-    LINK_NAMESPACE(fluid_settings_getstr_default, "libfluidsynth");
+    LINK_NAMESPACE(fluid_settings_getstr_default, "fluidsynth");
     return orig::fluid_settings_getstr_default(settings, name, def);
 }
 
@@ -47,7 +47,7 @@ int fluid_settings_setstr(fluid_settings_t *settings, const char *name, const ch
 {
     debuglogstdio(LCF_SOUND, "%s called with name %s", __func__, name);
 
-    LINK_NAMESPACE(fluid_settings_setstr, "libfluidsynth");
+    LINK_NAMESPACE(fluid_settings_setstr, "fluidsynth");
 
     int ret;
 
@@ -66,7 +66,7 @@ fluid_settings_t* new_fluid_settings(void)
     DEBUGLOGCALL(LCF_SOUND);
 
     /* Before creating the settings, we unregister every audio drivers except ALSA */
-    LINK_NAMESPACE(fluid_audio_driver_register, "libfluidsynth");
+    LINK_NAMESPACE(fluid_audio_driver_register, "fluidsynth");
     const char* alsadriver = "alsa";
     const char* adrivers[2] = {alsadriver, nullptr};
     int ret = orig::fluid_audio_driver_register(adrivers);
@@ -76,7 +76,7 @@ fluid_settings_t* new_fluid_settings(void)
     } // FLUID_OK
 
     /* Then return the original function */
-    LINK_NAMESPACE(new_fluid_settings, "libfluidsynth");
+    LINK_NAMESPACE(new_fluid_settings, "fluidsynth");
     return orig::new_fluid_settings();
 }
 

--- a/src/library/audio/fmod/fmod.cpp
+++ b/src/library/audio/fmod/fmod.cpp
@@ -33,8 +33,8 @@ int FMOD_System_Create(void **system)
 {
     DEBUGLOGCALL(LCF_SOUND);
 
-    LINK_NAMESPACE(FMOD_System_Create, "libfmod");
-    LINK_NAMESPACE(FMOD_System_SetOutput, "libfmod");
+    LINK_NAMESPACE(FMOD_System_Create, "fmod");
+    LINK_NAMESPACE(FMOD_System_SetOutput, "fmod");
 
     int ret = orig::FMOD_System_Create(system);
 
@@ -48,9 +48,9 @@ int FMOD_EventSystem_Create(void **eventsystem)
 {
     DEBUGLOGCALL(LCF_SOUND);
 
-    LINK_NAMESPACE(FMOD_EventSystem_Create, "libfmod");
-    LINK_NAMESPACE(FMOD_EventSystem_GetSystemObject, "libfmod");
-    LINK_NAMESPACE(FMOD_System_SetOutput, "libfmod");
+    LINK_NAMESPACE(FMOD_EventSystem_Create, "fmod");
+    LINK_NAMESPACE(FMOD_EventSystem_GetSystemObject, "fmod");
+    LINK_NAMESPACE(FMOD_System_SetOutput, "fmod");
 
     int ret = orig::FMOD_EventSystem_Create(eventsystem);
 
@@ -66,7 +66,7 @@ int FMOD_System_SetOutput(void *system, int)
 {
     DEBUGLOGCALL(LCF_SOUND);
 
-    LINK_NAMESPACE(FMOD_System_SetOutput, "libfmod");
+    LINK_NAMESPACE(FMOD_System_SetOutput, "fmod");
 
     /* We force the output to be ALSA */
     return orig::FMOD_System_SetOutput(system, 11 /* FMOD_OUTPUTTYPE_ALSA */);
@@ -76,7 +76,7 @@ int _ZN4FMOD6System9setOutputE15FMOD_OUTPUTTYPE(void *system, int output)
 {
     DEBUGLOGCALL(LCF_SOUND);
 
-    LINK_NAMESPACE(_ZN4FMOD6System9setOutputE15FMOD_OUTPUTTYPE, "libfmod");
+    LINK_NAMESPACE(_ZN4FMOD6System9setOutputE15FMOD_OUTPUTTYPE, "fmod");
 
     /* We force the output to be ALSA */
     return orig::_ZN4FMOD6System9setOutputE15FMOD_OUTPUTTYPE(system, 11 /* FMOD_OUTPUTTYPE_ALSA */);

--- a/src/library/fileio/generaliowrappers.cpp
+++ b/src/library/fileio/generaliowrappers.cpp
@@ -32,7 +32,7 @@ DEFINE_ORIG_POINTER(unlink)
 
 int rename (const char *oldf, const char *newf) throw()
 {
-    LINK_NAMESPACE(rename, nullptr);
+    LINK_NAMESPACE_GLOBAL(rename);
 
     if (GlobalState::isNative())
         return orig::rename(oldf, newf);
@@ -51,7 +51,7 @@ int rename (const char *oldf, const char *newf) throw()
 /* Remove file FILENAME.  */
 int remove (const char *filename) throw()
 {
-    LINK_NAMESPACE(remove, nullptr);
+    LINK_NAMESPACE_GLOBAL(remove);
 
     if (GlobalState::isNative())
         return orig::remove(filename);
@@ -70,7 +70,7 @@ int remove (const char *filename) throw()
 /* Remove the link NAME.  */
 int unlink (const char *name) throw()
 {
-    LINK_NAMESPACE(unlink, nullptr);
+    LINK_NAMESPACE_GLOBAL(unlink);
 
     if (GlobalState::isNative())
         return orig::unlink(name);

--- a/src/library/fileio/posixiowrappers.cpp
+++ b/src/library/fileio/posixiowrappers.cpp
@@ -53,7 +53,7 @@ DEFINE_ORIG_POINTER(dup2)
 
 int open (const char *file, int oflag, ...)
 {
-    LINK_NAMESPACE(open, nullptr);
+    LINK_NAMESPACE_GLOBAL(open);
 
     mode_t mode;
     if ((oflag & O_CREAT) || (oflag & O_TMPFILE))
@@ -94,7 +94,7 @@ int open (const char *file, int oflag, ...)
 
 int open64 (const char *file, int oflag, ...)
 {
-    LINK_NAMESPACE(open64, nullptr);
+    LINK_NAMESPACE_GLOBAL(open64);
 
     mode_t mode;
     if ((oflag & O_CREAT) || (oflag & O_TMPFILE))
@@ -135,7 +135,7 @@ int open64 (const char *file, int oflag, ...)
 
 int openat (int dirfd, const char *file, int oflag, ...)
 {
-    LINK_NAMESPACE(openat, nullptr);
+    LINK_NAMESPACE_GLOBAL(openat);
 
     mode_t mode;
     if ((oflag & O_CREAT) || (oflag & O_TMPFILE))
@@ -167,7 +167,7 @@ int openat (int dirfd, const char *file, int oflag, ...)
 
 int openat64 (int dirfd, const char *file, int oflag, ...)
 {
-    LINK_NAMESPACE(openat64, nullptr);
+    LINK_NAMESPACE_GLOBAL(openat64);
 
     mode_t mode;
     if ((oflag & O_CREAT) || (oflag & O_TMPFILE))
@@ -199,7 +199,7 @@ int openat64 (int dirfd, const char *file, int oflag, ...)
 
 int creat (const char *file, mode_t mode)
 {
-    LINK_NAMESPACE(creat, nullptr);
+    LINK_NAMESPACE_GLOBAL(creat);
 
     if (GlobalState::isNative())
         return orig::creat(file, mode);
@@ -226,7 +226,7 @@ int creat (const char *file, mode_t mode)
 
 int creat64 (const char *file, mode_t mode)
 {
-    LINK_NAMESPACE(creat64, nullptr);
+    LINK_NAMESPACE_GLOBAL(creat64);
 
     if (GlobalState::isNative())
         return orig::creat64(file, mode);
@@ -250,7 +250,7 @@ int creat64 (const char *file, mode_t mode)
 
 int close (int fd)
 {
-    LINK_NAMESPACE(close, nullptr);
+    LINK_NAMESPACE_GLOBAL(close);
 
     if (GlobalState::isNative())
         return orig::close(fd);
@@ -275,7 +275,7 @@ int close (int fd)
 
 int access(const char *name, int type) throw()
 {
-    LINK_NAMESPACE(access, nullptr);
+    LINK_NAMESPACE_GLOBAL(access);
 
     if (GlobalState::isNative())
         return orig::access(name, type);
@@ -311,7 +311,7 @@ int access(const char *name, int type) throw()
 
 int __xstat(int ver, const char *path, struct stat *buf) throw()
 {
-    LINK_NAMESPACE(__xstat, nullptr);
+    LINK_NAMESPACE_GLOBAL(__xstat);
 
     if (GlobalState::isNative())
         return orig::__xstat(ver, path, buf);
@@ -349,7 +349,7 @@ int __xstat(int ver, const char *path, struct stat *buf) throw()
 
 int __xstat64(int ver, const char *path, struct stat64 *buf) throw()
 {
-    LINK_NAMESPACE(__xstat64, nullptr);
+    LINK_NAMESPACE_GLOBAL(__xstat64);
 
     if (GlobalState::isNative())
         return orig::__xstat64(ver, path, buf);
@@ -387,7 +387,7 @@ int __xstat64(int ver, const char *path, struct stat64 *buf) throw()
 
 int __lxstat(int ver, const char *path, struct stat *buf) throw()
 {
-    LINK_NAMESPACE(__lxstat, nullptr);
+    LINK_NAMESPACE_GLOBAL(__lxstat);
 
     if (GlobalState::isNative())
         return orig::__lxstat(ver, path, buf);
@@ -425,7 +425,7 @@ int __lxstat(int ver, const char *path, struct stat *buf) throw()
 
 int __lxstat64(int ver, const char *path, struct stat64 *buf) throw()
 {
-    LINK_NAMESPACE(__lxstat64, nullptr);
+    LINK_NAMESPACE_GLOBAL(__lxstat64);
 
     if (GlobalState::isNative())
         return orig::__lxstat64(ver, path, buf);
@@ -463,7 +463,7 @@ int __lxstat64(int ver, const char *path, struct stat64 *buf) throw()
 
 int __fxstat(int ver, int fd, struct stat *buf) throw()
 {
-    LINK_NAMESPACE(__fxstat, nullptr);
+    LINK_NAMESPACE_GLOBAL(__fxstat);
 
     if (GlobalState::isNative())
         return orig::__fxstat(ver, fd, buf);
@@ -474,7 +474,7 @@ int __fxstat(int ver, int fd, struct stat *buf) throw()
 
 int __fxstat64(int ver, int fd, struct stat64 *buf) throw()
 {
-    LINK_NAMESPACE(__fxstat64, nullptr);
+    LINK_NAMESPACE_GLOBAL(__fxstat64);
 
     if (GlobalState::isNative())
         return orig::__fxstat64(ver, fd, buf);
@@ -486,7 +486,7 @@ int __fxstat64(int ver, int fd, struct stat64 *buf) throw()
 int dup2 (int fd, int fd2) throw()
 {
     debuglogstdio(LCF_FILEIO, "%s call: %d -> %d", __func__, fd2, fd);
-    LINK_NAMESPACE(dup2, nullptr);
+    LINK_NAMESPACE_GLOBAL(dup2);
 
     if (fd2 == 2) {
         /* Prevent the game from redirecting stderr (2) to a file */

--- a/src/library/hook.h
+++ b/src/library/hook.h
@@ -46,11 +46,11 @@ namespace orig { \
     static decltype(&FUNC) FUNC; \
 }
 
-#define LINK_NAMESPACE(FUNC,LIB) link_function((void**)&orig::FUNC, #FUNC, LIB)
-#define LINK_NAMESPACE_GLOBAL(FUNC) LINK_NAMESPACE(FUNC, nullptr)
-#define LINK_NAMESPACE_VERSION(FUNC,LIB,V) link_function((void**)&orig::FUNC, #FUNC, LIB, V)
-#define LINK_NAMESPACE_SDL1(FUNC) LINK_NAMESPACE(FUNC,"libSDL-1.2.so.0")
-#define LINK_NAMESPACE_SDL2(FUNC) LINK_NAMESPACE(FUNC,"libSDL2-2.0.so.0")
+#define LINK_NAMESPACE(FUNC,LIB) link_function((void**)&orig::FUNC, #FUNC, "lib" LIB ".so")
+#define LINK_NAMESPACE_GLOBAL(FUNC) link_function((void**)&orig::FUNC, #FUNC, nullptr)
+#define LINK_NAMESPACE_VERSION(FUNC,LIB,V) link_function((void**)&orig::FUNC, #FUNC, "lib" LIB ".so", V)
+#define LINK_NAMESPACE_SDL1(FUNC) LINK_NAMESPACE(FUNC,"SDL-1.2")
+#define LINK_NAMESPACE_SDL2(FUNC) LINK_NAMESPACE(FUNC,"SDL2-2.0")
 #define LINK_NAMESPACE_SDLX(FUNC) (get_sdlversion()==1)?LINK_NAMESPACE_SDL1(FUNC):LINK_NAMESPACE_SDL2(FUNC)
 
 

--- a/src/library/inputs/ioctl_joy.cpp
+++ b/src/library/inputs/ioctl_joy.cpp
@@ -41,7 +41,7 @@ DEFINE_ORIG_POINTER(ioctl);
 int ioctl(int fd, unsigned long request, ...) throw()
 {
     //debuglog(LCF_JOYSTICK, __func__, " call on device ", fd);
-    LINK_NAMESPACE(ioctl, nullptr);
+    LINK_NAMESPACE_GLOBAL(ioctl);
 
     va_list arg_list;
     void* argp;

--- a/src/library/openglwrappers.cpp
+++ b/src/library/openglwrappers.cpp
@@ -129,7 +129,7 @@ void checkMesa()
     checked = true;
 
     /* Get OpenGL vendor and renderer */
-    LINK_NAMESPACE(glGetString, "libGL");
+    LINK_NAMESPACE(glGetString, "GL");
     const char* vendor = reinterpret_cast<const char*>(orig::glGetString(GL_VENDOR));
     const char* renderer = reinterpret_cast<const char*>(orig::glGetString(GL_RENDERER));
 
@@ -222,7 +222,7 @@ static void* store_orig_and_return_my_symbol(const GLubyte* symbol, void* real_p
 void(*glXGetProcAddress (const GLubyte *procName))()
 {
     debuglog(LCF_OGL, __func__, " call with symbol ", procName);
-    LINK_NAMESPACE(glXGetProcAddress, "libGL");
+    LINK_NAMESPACE(glXGetProcAddress, "GL");
 
     if (!orig::glXGetProcAddress) return nullptr;
 
@@ -232,7 +232,7 @@ void(*glXGetProcAddress (const GLubyte *procName))()
 __GLXextFuncPtr glXGetProcAddressARB (const GLubyte *procName)
 {
     debuglog(LCF_OGL, __func__, " call with symbol ", procName);
-    LINK_NAMESPACE(glXGetProcAddressARB, "libGL");
+    LINK_NAMESPACE(glXGetProcAddressARB, "GL");
 
     if (!orig::glXGetProcAddressARB) return nullptr;
 
@@ -242,7 +242,7 @@ __GLXextFuncPtr glXGetProcAddressARB (const GLubyte *procName)
 void* glXGetProcAddressEXT (const GLubyte *procName)
 {
     debuglog(LCF_OGL, __func__, " call with symbol ", procName);
-    LINK_NAMESPACE(glXGetProcAddressEXT, "libGL");
+    LINK_NAMESPACE(glXGetProcAddressEXT, "GL");
 
     if (!orig::glXGetProcAddressEXT) return nullptr;
 
@@ -251,7 +251,7 @@ void* glXGetProcAddressEXT (const GLubyte *procName)
 
 Bool glXMakeCurrent( Display *dpy, GLXDrawable drawable, GLXContext ctx )
 {
-    LINK_NAMESPACE(glXMakeCurrent, "libGL");
+    LINK_NAMESPACE(glXMakeCurrent, "GL");
 
     Bool ret = orig::glXMakeCurrent(dpy, drawable, ctx);
     if (GlobalState::isNative())
@@ -276,7 +276,7 @@ Bool glXMakeCurrent( Display *dpy, GLXDrawable drawable, GLXContext ctx )
     }
 
     /* Disable VSync */
-    //LINK_NAMESPACE(glXGetProcAddressARB, "libGL");
+    //LINK_NAMESPACE(glXGetProcAddressARB, "GL");
     //orig::glXSwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC)orig::glXGetProcAddressARB((const GLubyte*)"glXSwapIntervalEXT");
     //orig::glXSwapIntervalEXT(dpy, drawable, 0);
 
@@ -285,7 +285,7 @@ Bool glXMakeCurrent( Display *dpy, GLXDrawable drawable, GLXContext ctx )
 
 void glXSwapBuffers( Display *dpy, XID drawable )
 {
-    LINK_NAMESPACE(glXSwapBuffers, "libGL");
+    LINK_NAMESPACE(glXSwapBuffers, "GL");
 
     if (GlobalState::isNative())
         return orig::glXSwapBuffers(dpy, drawable);
@@ -306,7 +306,7 @@ static int swapInterval = 0;
 void glXSwapIntervalEXT (Display *dpy, GLXDrawable drawable, int interval)
 {
     debuglog(LCF_OGL, __func__, " call with interval ", interval);
-    LINK_NAMESPACE(glXSwapIntervalEXT, "libGL");
+    LINK_NAMESPACE(glXSwapIntervalEXT, "GL");
 
     swapInterval = interval;
 
@@ -323,7 +323,7 @@ void glXSwapIntervalEXT (Display *dpy, GLXDrawable drawable, int interval)
 int glXSwapIntervalSGI (int interval)
 {
     debuglog(LCF_OGL, __func__, " call with interval ", interval);
-    LINK_NAMESPACE(glXSwapIntervalSGI, "libGL");
+    LINK_NAMESPACE(glXSwapIntervalSGI, "GL");
 
     swapInterval = interval;
 
@@ -339,7 +339,7 @@ int glXSwapIntervalSGI (int interval)
 int glXSwapIntervalMESA (unsigned int interval)
 {
     debuglog(LCF_OGL, __func__, " call with interval ", interval);
-    LINK_NAMESPACE(glXSwapIntervalMESA, "libGL");
+    LINK_NAMESPACE(glXSwapIntervalMESA, "GL");
 
     swapInterval = interval;
 
@@ -371,14 +371,14 @@ void glXQueryDrawable(Display * dpy,  GLXDrawable draw,  int attribute,  unsigne
         return;
     }
 
-    LINK_NAMESPACE(glXQueryDrawable, "libGL");
+    LINK_NAMESPACE(glXQueryDrawable, "GL");
     return orig::glXQueryDrawable(dpy, draw, attribute, value);
 }
 
 GLXContext glXCreateContextAttribsARB (Display *dpy, GLXFBConfig config, GLXContext share_context, Bool direct, const int *attrib_list)
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glXCreateContextAttribsARB, "libGL");
+    LINK_NAMESPACE(glXCreateContextAttribsARB, "GL");
     int i = 0;
     while (attrib_list[i] != 0) {
         if (attrib_list[i] == GLX_CONTEXT_MAJOR_VERSION_ARB) {
@@ -411,7 +411,7 @@ GLXContext glXCreateContextAttribsARB (Display *dpy, GLXFBConfig config, GLXCont
 void glClear(GLbitfield mask)
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glClear, "libGL");
+    LINK_NAMESPACE(glClear, "GL");
     if (!skipping_draw)
         return orig::glClear(mask);
 }
@@ -427,7 +427,7 @@ void myglClear(GLbitfield mask)
 void glBegin(GLenum mode)
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glBegin, "libGL");
+    LINK_NAMESPACE(glBegin, "GL");
     if (!skipping_draw)
         return orig::glBegin(mode);
 }
@@ -435,7 +435,7 @@ void glBegin(GLenum mode)
 void glEnd(void)
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glEnd, "libGL");
+    LINK_NAMESPACE(glEnd, "GL");
     if (!skipping_draw)
         return orig::glEnd();
 }
@@ -443,7 +443,7 @@ void glEnd(void)
 void glVertex2d( GLdouble x, GLdouble y )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2d, "libGL");
+    LINK_NAMESPACE(glVertex2d, "GL");
     if (!skipping_draw)
         return orig::glVertex2d(x, y);
 }
@@ -451,7 +451,7 @@ void glVertex2d( GLdouble x, GLdouble y )
 void glVertex2f( GLfloat x, GLfloat y )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2f, "libGL");
+    LINK_NAMESPACE(glVertex2f, "GL");
     if (!skipping_draw)
         return orig::glVertex2f(x, y);
 }
@@ -459,7 +459,7 @@ void glVertex2f( GLfloat x, GLfloat y )
 void glVertex2i( GLint x, GLint y )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2i, "libGL");
+    LINK_NAMESPACE(glVertex2i, "GL");
     if (!skipping_draw)
         return orig::glVertex2i(x, y);
 }
@@ -467,7 +467,7 @@ void glVertex2i( GLint x, GLint y )
 void glVertex2s( GLshort x, GLshort y )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2s, "libGL");
+    LINK_NAMESPACE(glVertex2s, "GL");
     if (!skipping_draw)
         return orig::glVertex2s(x, y);
 }
@@ -475,7 +475,7 @@ void glVertex2s( GLshort x, GLshort y )
 void glVertex3d( GLdouble x, GLdouble y, GLdouble z )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3d, "libGL");
+    LINK_NAMESPACE(glVertex3d, "GL");
     if (!skipping_draw)
         return orig::glVertex3d(x, y, z);
 }
@@ -483,7 +483,7 @@ void glVertex3d( GLdouble x, GLdouble y, GLdouble z )
 void glVertex3f( GLfloat x, GLfloat y, GLfloat z )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3f, "libGL");
+    LINK_NAMESPACE(glVertex3f, "GL");
     if (!skipping_draw)
         return orig::glVertex3f(x, y, z);
 }
@@ -491,7 +491,7 @@ void glVertex3f( GLfloat x, GLfloat y, GLfloat z )
 void glVertex3i( GLint x, GLint y, GLint z )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3i, "libGL");
+    LINK_NAMESPACE(glVertex3i, "GL");
     if (!skipping_draw)
         return orig::glVertex3i(x, y, z);
 }
@@ -499,7 +499,7 @@ void glVertex3i( GLint x, GLint y, GLint z )
 void glVertex3s( GLshort x, GLshort y, GLshort z )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3s, "libGL");
+    LINK_NAMESPACE(glVertex3s, "GL");
     if (!skipping_draw)
         return orig::glVertex3s(x, y, z);
 }
@@ -507,7 +507,7 @@ void glVertex3s( GLshort x, GLshort y, GLshort z )
 void glVertex4d( GLdouble x, GLdouble y, GLdouble z, GLdouble w )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4d, "libGL");
+    LINK_NAMESPACE(glVertex4d, "GL");
     if (!skipping_draw)
         return orig::glVertex4d(x, y, z, w);
 }
@@ -515,7 +515,7 @@ void glVertex4d( GLdouble x, GLdouble y, GLdouble z, GLdouble w )
 void glVertex4f( GLfloat x, GLfloat y, GLfloat z, GLfloat w )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4f, "libGL");
+    LINK_NAMESPACE(glVertex4f, "GL");
     if (!skipping_draw)
         return orig::glVertex4f(x, y, z, w);
 }
@@ -523,7 +523,7 @@ void glVertex4f( GLfloat x, GLfloat y, GLfloat z, GLfloat w )
 void glVertex4i( GLint x, GLint y, GLint z, GLint w )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4i, "libGL");
+    LINK_NAMESPACE(glVertex4i, "GL");
     if (!skipping_draw)
         return orig::glVertex4i(x, y, z, w);
 }
@@ -531,7 +531,7 @@ void glVertex4i( GLint x, GLint y, GLint z, GLint w )
 void glVertex4s( GLshort x, GLshort y, GLshort z, GLshort w )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4s, "libGL");
+    LINK_NAMESPACE(glVertex4s, "GL");
     if (!skipping_draw)
         return orig::glVertex4s(x, y, z, w);
 }
@@ -539,7 +539,7 @@ void glVertex4s( GLshort x, GLshort y, GLshort z, GLshort w )
 void glVertex2dv( const GLdouble *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2dv, "libGL");
+    LINK_NAMESPACE(glVertex2dv, "GL");
     if (!skipping_draw)
         return orig::glVertex2dv(v);
 }
@@ -547,7 +547,7 @@ void glVertex2dv( const GLdouble *v )
 void glVertex2fv( const GLfloat *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2fv, "libGL");
+    LINK_NAMESPACE(glVertex2fv, "GL");
     if (!skipping_draw)
         return orig::glVertex2fv(v);
 }
@@ -555,7 +555,7 @@ void glVertex2fv( const GLfloat *v )
 void glVertex2iv( const GLint *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2iv, "libGL");
+    LINK_NAMESPACE(glVertex2iv, "GL");
     if (!skipping_draw)
         return orig::glVertex2iv(v);
 }
@@ -563,7 +563,7 @@ void glVertex2iv( const GLint *v )
 void glVertex2sv( const GLshort *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex2sv, "libGL");
+    LINK_NAMESPACE(glVertex2sv, "GL");
     if (!skipping_draw)
         return orig::glVertex2sv(v);
 }
@@ -571,7 +571,7 @@ void glVertex2sv( const GLshort *v )
 void glVertex3dv( const GLdouble *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3dv, "libGL");
+    LINK_NAMESPACE(glVertex3dv, "GL");
     if (!skipping_draw)
         return orig::glVertex3dv(v);
 }
@@ -579,7 +579,7 @@ void glVertex3dv( const GLdouble *v )
 void glVertex3fv( const GLfloat *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3fv, "libGL");
+    LINK_NAMESPACE(glVertex3fv, "GL");
     if (!skipping_draw)
         return orig::glVertex3fv(v);
 }
@@ -587,7 +587,7 @@ void glVertex3fv( const GLfloat *v )
 void glVertex3iv( const GLint *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3iv, "libGL");
+    LINK_NAMESPACE(glVertex3iv, "GL");
     if (!skipping_draw)
         return orig::glVertex3iv(v);
 }
@@ -595,7 +595,7 @@ void glVertex3iv( const GLint *v )
 void glVertex3sv( const GLshort *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex3sv, "libGL");
+    LINK_NAMESPACE(glVertex3sv, "GL");
     if (!skipping_draw)
         return orig::glVertex3sv(v);
 }
@@ -604,7 +604,7 @@ void glVertex3sv( const GLshort *v )
 void glVertex4dv( const GLdouble *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4dv, "libGL");
+    LINK_NAMESPACE(glVertex4dv, "GL");
     if (!skipping_draw)
         return orig::glVertex4dv(v);
 }
@@ -612,7 +612,7 @@ void glVertex4dv( const GLdouble *v )
 void glVertex4fv( const GLfloat *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4fv, "libGL");
+    LINK_NAMESPACE(glVertex4fv, "GL");
     if (!skipping_draw)
         return orig::glVertex4fv(v);
 }
@@ -620,7 +620,7 @@ void glVertex4fv( const GLfloat *v )
 void glVertex4iv( const GLint *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4iv, "libGL");
+    LINK_NAMESPACE(glVertex4iv, "GL");
     if (!skipping_draw)
         return orig::glVertex4iv(v);
 }
@@ -628,7 +628,7 @@ void glVertex4iv( const GLint *v )
 void glVertex4sv( const GLshort *v )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glVertex4sv, "libGL");
+    LINK_NAMESPACE(glVertex4sv, "GL");
     if (!skipping_draw)
         return orig::glVertex4sv(v);
 }
@@ -636,7 +636,7 @@ void glVertex4sv( const GLshort *v )
 void glDrawArrays( GLenum mode, GLint first, GLsizei count )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glDrawArrays, "libGL");
+    LINK_NAMESPACE(glDrawArrays, "GL");
     if (!skipping_draw)
         return orig::glDrawArrays(mode, first, count);
 }
@@ -644,7 +644,7 @@ void glDrawArrays( GLenum mode, GLint first, GLsizei count )
 void glDrawElements( GLenum mode, GLsizei count, GLenum type, const GLvoid *indices )
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glDrawElements, "libGL");
+    LINK_NAMESPACE(glDrawElements, "GL");
     if (!skipping_draw)
         return orig::glDrawElements(mode, count, type, indices);
 }
@@ -820,7 +820,7 @@ void myglDrawArraysEXT (GLenum mode, GLint first, GLsizei count)
 void glBlitFramebuffer (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)
 {
     DEBUGLOGCALL(LCF_OGL);
-    LINK_NAMESPACE(glBlitFramebuffer, "libGL");
+    LINK_NAMESPACE(glBlitFramebuffer, "GL");
     if (!skipping_draw)
         return orig::glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }

--- a/src/library/randomwrappers.cpp
+++ b/src/library/randomwrappers.cpp
@@ -56,7 +56,7 @@ DEFINE_ORIG_POINTER(lcong48_r)
 /* Override */ long int random (void) throw()
 {
     static int count = 0;
-    LINK_NAMESPACE(random, nullptr);
+    LINK_NAMESPACE_GLOBAL(random);
     long int ret = orig::random();
     debuglog(LCF_RANDOM, __func__, " call ", count++, ", returning ", ret);
     return ret;
@@ -65,7 +65,7 @@ DEFINE_ORIG_POINTER(lcong48_r)
 /* Override */ void srandom (unsigned int seed) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed);
-    LINK_NAMESPACE(srandom, nullptr);
+    LINK_NAMESPACE_GLOBAL(srandom);
     return orig::srandom(seed);
 }
 
@@ -73,14 +73,14 @@ DEFINE_ORIG_POINTER(lcong48_r)
             size_t statelen) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed);
-    LINK_NAMESPACE(initstate, nullptr);
+    LINK_NAMESPACE_GLOBAL(initstate);
     return orig::initstate(seed, statebuf, statelen);
 }
 
 /* Override */ char *setstate (char *statebuf) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(setstate, nullptr);
+    LINK_NAMESPACE_GLOBAL(setstate);
     return orig::setstate(statebuf);
 }
 
@@ -88,14 +88,14 @@ DEFINE_ORIG_POINTER(lcong48_r)
              int32_t *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(random_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(random_r);
     return orig::random_r(buf, result);
 }
 
 /* Override */ int srandom_r (unsigned int seed, struct random_data *buf) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed);
-    LINK_NAMESPACE(srandom_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(srandom_r);
     return orig::srandom_r(seed, buf);
 }
 
@@ -103,21 +103,21 @@ DEFINE_ORIG_POINTER(lcong48_r)
             struct random_data *buf) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed);
-    LINK_NAMESPACE(initstate_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(initstate_r);
     return orig::initstate_r(seed, statebuf, statelen, buf);
 }
 
 /* Override */ int setstate_r (char *statebuf, struct random_data *buf) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(setstate_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(setstate_r);
     return orig::setstate_r(statebuf, buf);
 }
 
 /* Override */ int rand (void) throw()
 {
     static int count = 0;
-    LINK_NAMESPACE(rand, nullptr);
+    LINK_NAMESPACE_GLOBAL(rand);
     int ret = orig::rand();
     debuglog(LCF_RANDOM, __func__, " call ", count++, ", returning ", ret);
     return ret;
@@ -126,84 +126,84 @@ DEFINE_ORIG_POINTER(lcong48_r)
 /* Override */ void srand (unsigned int seed) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed);
-    LINK_NAMESPACE(srand, nullptr);
+    LINK_NAMESPACE_GLOBAL(srand);
     return orig::srand(seed);
 }
 
 /* Override */ int rand_r (unsigned int *seed) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(rand_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(rand_r);
     return orig::rand_r(seed);
 }
 
 /* Override */ double drand48 (void) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(drand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(drand48);
     return orig::drand48();
 }
 
 /* Override */ double erand48 (unsigned short int xsubi[3]) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(erand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(erand48);
     return orig::erand48(xsubi);
 }
 
 /* Override */ long int lrand48 (void) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(lrand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(lrand48);
     return orig::lrand48();
 }
 
 /* Override */ long int nrand48 (unsigned short int xsubi[3]) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(nrand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(nrand48);
     return orig::nrand48(xsubi);
 }
 
 /* Override */ long int mrand48 (void) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(mrand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(mrand48);
     return orig::mrand48();
 }
 
 /* Override */ long int jrand48 (unsigned short int xsubi[3]) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(jrand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(jrand48);
     return orig::jrand48(xsubi);
 }
 
 /* Override */ void srand48 (long int seedval) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seedval);
-    LINK_NAMESPACE(srand48, nullptr);
+    LINK_NAMESPACE_GLOBAL(srand48);
     return orig::srand48(seedval);
 }
 
 /* Override */ unsigned short int *seed48 (unsigned short int seed16v[3]) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed16v[0], " ", seed16v[1], " ", seed16v[2]);
-    LINK_NAMESPACE(seed48, nullptr);
+    LINK_NAMESPACE_GLOBAL(seed48);
     return orig::seed48(seed16v);
 }
 
 /* Override */ void lcong48 (unsigned short int param[7]) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(lcong48, nullptr);
+    LINK_NAMESPACE_GLOBAL(lcong48);
     return orig::lcong48(param);
 }
 
 /* Override */ int drand48_r (struct drand48_data *buffer, double *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(drand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(drand48_r);
     return orig::drand48_r(buffer, result);
 }
 
@@ -211,14 +211,14 @@ DEFINE_ORIG_POINTER(lcong48_r)
               struct drand48_data *buffer, double *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(erand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(erand48_r);
     return orig::erand48_r(xsubi, buffer, result);
 }
 
 /* Override */ int lrand48_r (struct drand48_data *buffer, long int *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(lrand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(lrand48_r);
     return orig::lrand48_r(buffer, result);
 }
 
@@ -226,14 +226,14 @@ DEFINE_ORIG_POINTER(lcong48_r)
               struct drand48_data *buffer, long int *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(nrand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(nrand48_r);
     return orig::nrand48_r(xsubi, buffer, result);
 }
 
 /* Override */ int mrand48_r (struct drand48_data *buffer, long int *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(mrand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(mrand48_r);
     return orig::mrand48_r(buffer, result);
 }
 
@@ -241,14 +241,14 @@ DEFINE_ORIG_POINTER(lcong48_r)
               struct drand48_data *buffer, long int *result) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(jrand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(jrand48_r);
     return orig::jrand48_r(xsubi, buffer, result);
 }
 
 /* Override */ int srand48_r (long int seedval, struct drand48_data *buffer) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seedval);
-    LINK_NAMESPACE(srand48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(srand48_r);
     return orig::srand48_r(seedval, buffer);
 }
 
@@ -256,7 +256,7 @@ DEFINE_ORIG_POINTER(lcong48_r)
              struct drand48_data *buffer) throw()
 {
     debuglog(LCF_RANDOM, __func__, " call with seed ", seed16v[0], " ", seed16v[1], " ", seed16v[2]);
-    LINK_NAMESPACE(seed48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(seed48_r);
     return orig::seed48_r(seed16v, buffer);
 }
 
@@ -264,7 +264,7 @@ DEFINE_ORIG_POINTER(lcong48_r)
               struct drand48_data *buffer) throw()
 {
     DEBUGLOGCALL(LCF_RANDOM);
-    LINK_NAMESPACE(lcong48_r, nullptr);
+    LINK_NAMESPACE_GLOBAL(lcong48_r);
     return orig::lcong48_r(param, buffer);
 }
 

--- a/src/library/renderhud/RenderHUD_GL.cpp
+++ b/src/library/renderhud/RenderHUD_GL.cpp
@@ -54,16 +54,16 @@ RenderHUD_GL::~RenderHUD_GL() {
 void RenderHUD_GL::init()
 {
     if (texture == 0) {
-        LINK_NAMESPACE(glGenTextures, "libGL");
-        LINK_NAMESPACE(glGetIntegerv, "libGL");
-        LINK_NAMESPACE(glActiveTexture, "libGL");
-        LINK_NAMESPACE(glDeleteTextures, "libGL");
-        LINK_NAMESPACE(glBindTexture, "libGL");
+        LINK_NAMESPACE(glGenTextures, "GL");
+        LINK_NAMESPACE(glGetIntegerv, "GL");
+        LINK_NAMESPACE(glActiveTexture, "GL");
+        LINK_NAMESPACE(glDeleteTextures, "GL");
+        LINK_NAMESPACE(glBindTexture, "GL");
 
-        LINK_NAMESPACE(glGenFramebuffers, "libGL");
-        LINK_NAMESPACE(glBindFramebuffer, "libGL");
-        LINK_NAMESPACE(glFramebufferTexture2D, "libGL");
-        LINK_NAMESPACE(glDeleteFramebuffers, "libGL");
+        LINK_NAMESPACE(glGenFramebuffers, "GL");
+        LINK_NAMESPACE(glBindFramebuffer, "GL");
+        LINK_NAMESPACE(glFramebufferTexture2D, "GL");
+        LINK_NAMESPACE(glDeleteFramebuffers, "GL");
 
 
         /* Get previous active texture */
@@ -101,13 +101,13 @@ void RenderHUD_GL::fini()
 
 void RenderHUD_GL::renderText(const char* text, Color fg_color, Color bg_color, int x, int y)
 {
-    LINK_NAMESPACE(glBindTexture, "libGL");
-    LINK_NAMESPACE(glTexImage2D, "libGL");
-    LINK_NAMESPACE(glTexParameteri, "libGL");
+    LINK_NAMESPACE(glBindTexture, "GL");
+    LINK_NAMESPACE(glTexImage2D, "GL");
+    LINK_NAMESPACE(glTexParameteri, "GL");
 
-    LINK_NAMESPACE(glBlitFramebuffer, "libGL");
-    LINK_NAMESPACE(glUseProgram, "libGL");
-    LINK_NAMESPACE(glGetIntegerv, "libGL");
+    LINK_NAMESPACE(glBlitFramebuffer, "GL");
+    LINK_NAMESPACE(glUseProgram, "GL");
+    LINK_NAMESPACE(glGetIntegerv, "GL");
 
     /* Save the previous program */
     GLint oldProgram;

--- a/src/library/sdlversion.cpp
+++ b/src/library/sdlversion.cpp
@@ -44,8 +44,8 @@ int get_sdlversion(void)
     {
         /* Remove logging to not alert user on an expected error */
         GlobalNoLog gnl;
-        LINK_NAMESPACE(SDL_GetVersion, "libSDL");
-        LINK_NAMESPACE(SDL_Linked_Version, "libSDL");
+        LINK_NAMESPACE(SDL_GetVersion, "SDL");
+        LINK_NAMESPACE(SDL_Linked_Version, "SDL");
     }
 
     if (orig::SDL_GetVersion) {

--- a/src/library/signalwrappers.cpp
+++ b/src/library/signalwrappers.cpp
@@ -50,7 +50,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ sighandler_t signal (int sig, sighandler_t handler) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL);
-    LINK_NAMESPACE(signal, nullptr);
+    LINK_NAMESPACE_GLOBAL(signal);
 
     /* Our checkpoint code uses signals, so we must prevent the game from
      * signaling threads at the same time.
@@ -74,7 +74,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigblock (int mask) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL);
-    LINK_NAMESPACE(sigblock, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigblock);
 
     static const int bannedMask = sigmask(SIGUSR1) | sigmask(SIGUSR2);
 
@@ -93,7 +93,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigsetmask (int mask) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL);
-    LINK_NAMESPACE(sigsetmask, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigsetmask);
 
     static const int bannedMask = sigmask(SIGUSR1) | sigmask(SIGUSR2);
 
@@ -113,7 +113,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int siggetmask (void) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL);
-    LINK_NAMESPACE(siggetmask, nullptr);
+    LINK_NAMESPACE_GLOBAL(siggetmask);
 
     int oldmask = orig::siggetmask();
 
@@ -127,7 +127,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigprocmask (int how, const sigset_t *set, sigset_t *oset) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL);
-    LINK_NAMESPACE(sigprocmask, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigprocmask);
 
     if (GlobalState::isNative())
         return orig::sigprocmask(how, set, oset);
@@ -168,7 +168,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigsuspend (const sigset_t *set)
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_TODO);
-    LINK_NAMESPACE(sigsuspend, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigsuspend);
 
     sigset_t tmp;
     if (set) {
@@ -184,7 +184,7 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigaction (int sig, const struct sigaction *act,
     struct sigaction *oact) throw()
 {
-    LINK_NAMESPACE(sigaction, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigaction);
 
     if (GlobalState::isNative()) {
         return orig::sigaction(sig, act, oact);
@@ -220,21 +220,21 @@ static thread_local int origUsrMaskThread = 0;
 /* Override */ int sigpending (sigset_t *set) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_TODO);
-    LINK_NAMESPACE(sigpending, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigpending);
     return orig::sigpending(set);
 }
 
 /* Override */ int sigwait (const sigset_t *set, int *sig)
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_TODO);
-    LINK_NAMESPACE(sigwait, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigwait);
     return orig::sigwait(set, sig);
 }
 
 /* Override */ int sigwaitinfo (const sigset_t *set, siginfo_t *info)
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_TODO);
-    LINK_NAMESPACE(sigwaitinfo, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigwaitinfo);
     return orig::sigwaitinfo(set, info);
 }
 
@@ -242,13 +242,13 @@ static thread_local int origUsrMaskThread = 0;
     siginfo_t *info, const struct timespec *timeout)
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_TODO);
-    LINK_NAMESPACE(sigtimedwait, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigtimedwait);
     return orig::sigtimedwait(set, info, timeout);
 }
 
 /* Override */ int sigaltstack (const stack_t *ss, stack_t *oss) throw()
 {
-    LINK_NAMESPACE(sigaltstack, nullptr);
+    LINK_NAMESPACE_GLOBAL(sigaltstack);
 
     if (GlobalState::isNative()) {
         return orig::sigaltstack(ss, oss);
@@ -279,7 +279,7 @@ static thread_local int origUsrMaskThread = 0;
     sigset_t *oldmask) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_THREAD);
-    LINK_NAMESPACE(pthread_sigmask, nullptr);
+    LINK_NAMESPACE_GLOBAL(pthread_sigmask);
 
     /* This is a bit of a workaround. We still want native threads
      * (like pulseaudio thread) to be able to be suspended, but we also want
@@ -349,7 +349,7 @@ static thread_local int origUsrMaskThread = 0;
 
 /* Override */ int pthread_kill (pthread_t threadid, int signo) throw()
 {
-    LINK_NAMESPACE(pthread_kill, nullptr);
+    LINK_NAMESPACE_GLOBAL(pthread_kill);
 
     if (GlobalState::isNative())
         return orig::pthread_kill(threadid, signo);
@@ -372,7 +372,7 @@ static thread_local int origUsrMaskThread = 0;
                  const union sigval value) throw()
 {
     DEBUGLOGCALL(LCF_SIGNAL | LCF_THREAD);
-    LINK_NAMESPACE(pthread_sigqueue, nullptr);
+    LINK_NAMESPACE_GLOBAL(pthread_sigqueue);
     return orig::pthread_sigqueue(threadid, signo, value);
 }
 

--- a/src/library/sleepwrappers.cpp
+++ b/src/library/sleepwrappers.cpp
@@ -36,7 +36,7 @@ DEFINE_ORIG_POINTER(pselect);
 
 /* Override */ void SDL_Delay(unsigned int sleep)
 {
-    LINK_NAMESPACE(nanosleep, nullptr);
+    LINK_NAMESPACE_GLOBAL(nanosleep);
 
     struct timespec ts;
     ts.tv_sec = sleep / 1000;
@@ -64,7 +64,7 @@ DEFINE_ORIG_POINTER(pselect);
 
 /* Override */ int usleep(useconds_t usec)
 {
-    LINK_NAMESPACE(nanosleep, nullptr);
+    LINK_NAMESPACE_GLOBAL(nanosleep);
 
     struct timespec ts;
     ts.tv_sec = usec / 1000000;
@@ -91,7 +91,7 @@ DEFINE_ORIG_POINTER(pselect);
 
 /* Override */ int nanosleep (const struct timespec *requested_time, struct timespec *remaining)
 {
-    LINK_NAMESPACE(nanosleep, nullptr);
+    LINK_NAMESPACE_GLOBAL(nanosleep);
 
     if (GlobalState::isNative()) {
         return orig::nanosleep(requested_time, remaining);
@@ -116,7 +116,7 @@ DEFINE_ORIG_POINTER(pselect);
 			    const struct timespec *req,
 			    struct timespec *rem)
 {
-    LINK_NAMESPACE(clock_nanosleep, nullptr);
+    LINK_NAMESPACE_GLOBAL(clock_nanosleep);
     if (GlobalState::isNative()) {
         return orig::clock_nanosleep(clock_id, flags, req, rem);
     }
@@ -152,7 +152,7 @@ DEFINE_ORIG_POINTER(pselect);
 
 /* Override */ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout)
 {
-    LINK_NAMESPACE(select, nullptr);
+    LINK_NAMESPACE_GLOBAL(select);
 
     /* select can be used to sleep the cpu if feed with all null parameters
      * except for timeout. In this case we replace it with what we did for
@@ -189,7 +189,7 @@ DEFINE_ORIG_POINTER(pselect);
 /* Override */ int pselect (int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 	const struct timespec *timeout, const __sigset_t *sigmask)
 {
-    LINK_NAMESPACE(pselect, nullptr);
+    LINK_NAMESPACE_GLOBAL(pselect);
 
     /* select can be used to sleep the cpu if feed with all null parameters
      * except for timeout. In this case we replace it with what we did for

--- a/src/library/test/hooktest.cpp
+++ b/src/library/test/hooktest.cpp
@@ -46,7 +46,7 @@ DEFINE_ORIG_POINTER(libtasTestFunc3);
 /* Override */ int libtasTestFunc2()
 {
     DEBUGLOGCALL(LCF_HOOK);
-    LINK_NAMESPACE(libtasTestFunc2, "libhooklib2.so");
+    LINK_NAMESPACE(libtasTestFunc2, "hooklib2");
     if (!orig::libtasTestFunc2) {
         debuglog(LCF_HOOK | LCF_ERROR, "   Couldn't get original function");
     }
@@ -62,7 +62,7 @@ DEFINE_ORIG_POINTER(libtasTestFunc3);
 /* Override */ int libtasTestFunc3()
 {
     DEBUGLOGCALL(LCF_HOOK);
-    LINK_NAMESPACE(libtasTestFunc3, "libhooklib3.so");
+    LINK_NAMESPACE(libtasTestFunc3, "hooklib3");
     if (!orig::libtasTestFunc3) {
         debuglog(LCF_HOOK | LCF_ERROR, "   Couldn't get original function");
     }

--- a/src/library/timewrappers.cpp
+++ b/src/library/timewrappers.cpp
@@ -63,7 +63,7 @@ DEFINE_ORIG_POINTER(clock_gettime);
 /* Override */ int clock_gettime (clockid_t clock_id, struct timespec *tp) throw()
 {
     if (GlobalState::isNative()) {
-        LINK_NAMESPACE(clock_gettime, nullptr);
+        LINK_NAMESPACE_GLOBAL(clock_gettime);
         return orig::clock_gettime(clock_id, tp);
     }
 

--- a/src/library/xf86vidmode.cpp
+++ b/src/library/xf86vidmode.cpp
@@ -31,7 +31,7 @@ DEFINE_ORIG_POINTER(XF86VidModeGetAllModeLines);
 Bool XF86VidModeGetModeLine(Display* dpy, int screen, int* dotclock, XF86VidModeModeLine* modeline)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XF86VidModeGetModeLine, "libXxf86vm");
+    LINK_NAMESPACE(XF86VidModeGetModeLine, "Xxf86vm");
 
     Bool ret = orig::XF86VidModeGetModeLine(dpy, screen, dotclock, modeline);
 
@@ -55,7 +55,7 @@ Bool XF86VidModeGetModeLine(Display* dpy, int screen, int* dotclock, XF86VidMode
 Bool XF86VidModeGetAllModeLines(Display *dpy, int screen, int *modecount_return, XF86VidModeModeInfo ***modesinfo)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XF86VidModeGetAllModeLines, "libXxf86vm");
+    LINK_NAMESPACE(XF86VidModeGetAllModeLines, "Xxf86vm");
 
     Bool ret = orig::XF86VidModeGetAllModeLines(dpy, screen, modecount_return, modesinfo);
 

--- a/src/library/xrandr.cpp
+++ b/src/library/xrandr.cpp
@@ -30,7 +30,7 @@ DEFINE_ORIG_POINTER(XRRGetCrtcInfo);
 OVERRIDE XRRCrtcInfo *XRRGetCrtcInfo (Display *dpy, XRRScreenResources *resources, RRCrtc crtc)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XRRGetCrtcInfo, "libXrandr");
+    LINK_NAMESPACE(XRRGetCrtcInfo, "Xrandr");
 
     XRRCrtcInfo *crtcInfo = orig::XRRGetCrtcInfo(dpy, resources, crtc);
 

--- a/src/library/xwindows.cpp
+++ b/src/library/xwindows.cpp
@@ -99,7 +99,7 @@ Window XCreateWindow(Display *display, Window parent, int x, int y, unsigned int
 Window XCreateSimpleWindow(Display *display, Window parent, int x, int y, unsigned int width, unsigned int height, unsigned int border_width, unsigned long border, unsigned long background)
 {
     debuglog(LCF_WINDOW, __func__, " call with dimensions ", width, "x", height);
-    LINK_NAMESPACE(XCreateSimpleWindow, nullptr);
+    LINK_NAMESPACE_GLOBAL(XCreateSimpleWindow);
 
     Window w = orig::XCreateSimpleWindow(display, parent, x, y, width, height, border_width, border, background);
 
@@ -116,7 +116,7 @@ Window XCreateSimpleWindow(Display *display, Window parent, int x, int y, unsign
 int XDestroyWindow(Display *display, Window w)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XDestroyWindow, nullptr);
+    LINK_NAMESPACE_GLOBAL(XDestroyWindow);
 
     ScreenCapture::fini();
 
@@ -133,7 +133,7 @@ int XDestroyWindow(Display *display, Window w)
 int XMapWindow(Display *display, Window w)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XMapWindow, nullptr);
+    LINK_NAMESPACE_GLOBAL(XMapWindow);
 
     int ret = orig::XMapWindow(display, w);
 
@@ -152,7 +152,7 @@ int XMapWindow(Display *display, Window w)
 int XMapRaised(Display *display, Window w)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XMapRaised, nullptr);
+    LINK_NAMESPACE_GLOBAL(XMapRaised);
 
     int ret = orig::XMapRaised(display, w);
 
@@ -171,7 +171,7 @@ int XMapRaised(Display *display, Window w)
 int XStoreName(Display *display, Window w, const char *window_name)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XStoreName, nullptr);
+    LINK_NAMESPACE_GLOBAL(XStoreName);
 
     WindowTitle::setOriginalTitle(window_name);
     WindowTitle::setUpdateFunc([display, w] (const char* t) {orig::XStoreName(display, w, t);});
@@ -182,7 +182,7 @@ int XStoreName(Display *display, Window w, const char *window_name)
 void XSetWMName(Display *display, Window w, XTextProperty *text_prop)
 {
     debuglog(LCF_WINDOW, __func__, " call with name ", text_prop->value, " and format ", text_prop->format);
-    LINK_NAMESPACE(XSetWMName, nullptr);
+    LINK_NAMESPACE_GLOBAL(XSetWMName);
     Atom encoding = text_prop->encoding;
 
     WindowTitle::setOriginalTitle(reinterpret_cast<const char*>(const_cast<const unsigned char*>(text_prop->value)));
@@ -198,14 +198,14 @@ void XSetWMName(Display *display, Window w, XTextProperty *text_prop)
 Atom XInternAtom(Display* display, const char* atom_name, Bool only_if_exists)
 {
     debuglog(LCF_WINDOW, __func__, " call with atom ", atom_name);
-    LINK_NAMESPACE(XInternAtom, nullptr);
+    LINK_NAMESPACE_GLOBAL(XInternAtom);
     return orig::XInternAtom(display, atom_name, only_if_exists);
 }
 
 int XSelectInput(Display *display, Window w, long event_mask)
 {
     DEBUGLOGCALL(LCF_WINDOW);
-    LINK_NAMESPACE(XSelectInput, nullptr);
+    LINK_NAMESPACE_GLOBAL(XSelectInput);
 
     return orig::XSelectInput(display, w, event_mask);
 }


### PR DESCRIPTION
Various callers to `link_function` passed `NAME`, `libNAME`, or `libNAME.so` as the library name.  Most of the time the parameter is unused or searched as a substring of another string so it didn't matter.  However, the `/* If it did not succeed, try to link using the given library */` codepath requires the `libNAME.so` format in order to pass to `dlopen`.  This forcibly adds the `lib` and `.so` inside the `LINK_NAMESPACE` macros so that passing a format other than `NAME` will cause `link_function` to fail outright.