### PR TITLE
Set an environment variable with the current frame count.

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -120,6 +120,8 @@ void GameLoop::launchGameThread()
     /* Tell SDL >= 2.0.2 to let us override functions even if it is statically linked. */
     setenv("SDL_DYNAMIC_API", context->libtaspath.c_str(), 1);
 
+    setenv("LIBTAS_START_FRAME", std::to_string(context->framecount).c_str(), 1);
+
     /* Disable Address Space Layout Randomization for the game, so that ram
      * watch addresses do not change on game restart.
      * Source: https://stackoverflow.com/questions/5194666/disable-randomization-of-memory-addresses/30385370#30385370


### PR DESCRIPTION
This is useful for TASes that play multiple games in sequence or restart games with different arguments.

Used in https://github.com/BenLubar/tobytas/blob/55d0f7aff277b43cb2f5f5d0901df90f3e05c9a2/proxy.c