### PR TITLE
Use pipes for event queues

### DIFF
--- a/src/library/checkpoint/ThreadManager.cpp
+++ b/src/library/checkpoint/ThreadManager.cpp
@@ -367,7 +367,9 @@ void ThreadManager::checkpoint()
     /* Sending a suspend signal to all threads */
     suspendThreads();
 
-    /* We flag all opened files as tracked and store their offset. */
+    /* We flag all opened files as tracked and store their offset. This must be
+     * done AFTER suspending threads.
+     */
     FileHandleList::trackAllFiles();
 
     /* We set the alternate stack to our reserved memory. The game might
@@ -387,7 +389,9 @@ void ThreadManager::checkpoint()
     /* Restoring the game alternate stack (if any) */
     AltStack::restoreStack();
 
-    /* We recover the offset of all opened files */
+    /* We recover the offset of all opened files. This must also be done BEFORE
+     * resuming threads.
+     */
     FileHandleList::recoverAllFiles();
 
     resumeThreads();

--- a/src/library/fileio/FileHandleList.h
+++ b/src/library/fileio/FileHandleList.h
@@ -20,7 +20,7 @@
 #ifndef LIBTAS_FILEHANDLELIST_H_INCLUDED
 #define LIBTAS_FILEHANDLELIST_H_INCLUDED
 
-// #include <cstdio> // FILE
+#include <utility>
 
 namespace libtas {
 
@@ -28,6 +28,9 @@ namespace FileHandleList {
 
 /* Register an opened file and file descriptor */
 void openFile(const char* file, int fd);
+
+/* Open and register an unnamed pipe */
+std::pair<int, int> createPipe(int flags = 0);
 
 /* Register a file closing, and returns if we must actually close the file */
 bool closeFile(int fd);

--- a/src/library/fileio/posixiowrappers.cpp
+++ b/src/library/fileio/posixiowrappers.cpp
@@ -257,10 +257,14 @@ int close (int fd)
 
     debuglogstdio(LCF_FILEIO, "%s call", __func__);
 
-    close_jsdev(fd);
-    close_evdev(fd);
+    int ret = close_jsdev(fd);
 
-    int ret = SaveFileList::closeSaveFile(fd);
+    if (ret == 1)
+        ret = close_evdev(fd);
+
+    if (ret == 1)
+        ret = SaveFileList::closeSaveFile(fd);
+
     if (ret != 1)
         return ret;
 

--- a/src/library/fileio/posixiowrappers.cpp
+++ b/src/library/fileio/posixiowrappers.cpp
@@ -257,13 +257,7 @@ int close (int fd)
 
     debuglogstdio(LCF_FILEIO, "%s call", __func__);
 
-    int ret = close_jsdev(fd);
-
-    if (ret == 1)
-        ret = close_evdev(fd);
-
-    if (ret == 1)
-        ret = SaveFileList::closeSaveFile(fd);
+    int ret = SaveFileList::closeSaveFile(fd);
 
     if (ret != 1)
         return ret;

--- a/src/library/frame.cpp
+++ b/src/library/frame.cpp
@@ -365,17 +365,7 @@ void frameBoundary(bool drawFB, std::function<void()> draw, bool restore_screen)
     generateControllerEvents();
     generateMouseMotionEvents();
     generateMouseButtonEvents();
-
-    if ((game_info.keyboard & GameInfo::XEVENTS) || (game_info.mouse & GameInfo::XEVENTS)) {
-        /* Sync Xlib event queue, so that we are sure the input events will be
-         * pulled by the game on the next frame.
-         */
-        for (int i=0; i<GAMEDISPLAYNUM; i++) {
-            if (gameDisplays[i]) {
-                XSync(gameDisplays[i], False);
-            }
-        }
-    }
+    syncEvents();
 
     /* Decide if we skip drawing the next frame because of fastforward.
      * It is stored in an extern so that we can disable opengl draws.

--- a/src/library/inputs/evdev.cpp
+++ b/src/library/inputs/evdev.cpp
@@ -24,11 +24,11 @@
 #include "../DeterministicTimer.h"
 #include "../../shared/AllInputs.h"
 #include <unistd.h>
-#include <sys/syscall.h>
 
 namespace libtas {
 
-static int evdevfds[AllInputs::MAXJOYS] = {0};
+/* The subarray contains pipe in fd, pipe out fd, and refcount. */
+static int evdevfds[AllInputs::MAXJOYS][3] = {{0}};
 
 int is_evdev(const char* source)
 {
@@ -60,128 +60,62 @@ int open_evdev(const char* source, int flags)
 
     debuglog(LCF_JOYSTICK, "   evdev device ", evnum, " detected");
 
-    if (evdevfds[evnum] != 0) {
-        debuglog(LCF_JOYSTICK | LCF_ERROR, "Warning, evdev ", source, " opened multiple times!");
+    if (evdevfds[evnum][2]++ == 0) {
+        /* Register that we use EVDEV for joystick inputs */
+        game_info.joystick = GameInfo::EVDEV;
+        game_info.tosend = true;
+
+        /* Create an unnamed pipe. */
+        MYASSERT(pipe(evdevfds[evnum]) == 0);
+
+        /* Write the synthetic events corresponding to the initial state of the
+         * joystick. */
+        // struct js_event ev;
+        //
+        // struct timespec ts = detTimer.getTicks();
+        // ev.time = ts.tv_sec*1000 + ts.tv_nsec/1000000;
+        // ev.value = 0;
+        // for (int button = 0; button < 11; button++) {
+        //     ev.type = JS_EVENT_BUTTON | JS_EVENT_INIT;
+        //     ev.number = button;
+        //     write_jsdev(ev, jsnum);
+        // }
+        // for (int axis = 0; axis < 8; axis++) {
+        //     ev.type = JS_EVENT_AXIS | JS_EVENT_INIT;
+        //     ev.number = axis;
+        //     write_jsdev(ev, jsnum);
+        // }
     }
 
-    /* Register that we use JSDEV for joystick inputs */
-    game_info.joystick = GameInfo::EVDEV;
-    game_info.tosend = true;
-
-    /* Create an anonymous file and store its file descriptor using the
-     * recent memfd_create syscall.
-     */
-    int fd = syscall(SYS_memfd_create, source, 0);
-    evdevfds[evnum] = fd;
-
-    /* Write the synthetic events corresponding to the initial state of the
-     * joystick. */
-    // struct js_event ev;
-    //
-    // struct timespec ts = detTimer.getTicks();
-    // ev.time = ts.tv_sec*1000 + ts.tv_nsec/1000000;
-    // ev.value = 0;
-    // for (int button = 0; button < 11; button++) {
-    //     ev.type = JS_EVENT_BUTTON | JS_EVENT_INIT;
-    //     ev.number = button;
-    //     write_jsdev(ev, jsnum);
-    // }
-    // for (int axis = 0; axis < 8; axis++) {
-    //     ev.type = JS_EVENT_AXIS | JS_EVENT_INIT;
-    //     ev.number = axis;
-    //     write_jsdev(ev, jsnum);
-    // }
-
-    return fd;
+    return evdevfds[evnum][0];
 }
 
 void write_evdev(struct input_event ev, int evnum)
 {
-    int fd = evdevfds[evnum];
-
-    if (fd == 0)
-        return;
-
-    /* We must simulate a queue using our memfd structure (basically a file).
-     * Of course, we must not grow our file too much.
-     * One thing that helps us is that we can insert events of the same frame
-     * at any order. To acheive that, we insert the event backward from
-     * the file position if the next event is from the same frame (or eof).
-     *
-     *    <---------------------|~~~~~~~~~~~~~~~~~~~|------------------------>
-     *            read         new       new       old         unread
-     *                       position   event    position
-     *
-     * For any other case, we append at the end.
-     *
-     *    <|---------------------------------------------------|+++++++++++++>
-     *  old/new                 unread                            new event
-     *  position
-     *
-     */
-
-    off_t curpos = lseek(fd, 0, SEEK_CUR);
-    MYASSERT(curpos >= 0)
-
-    off_t ev_size = static_cast<off_t>(sizeof(struct input_event));
-
-    if (curpos > 0) {
-        MYASSERT(curpos >= ev_size)
-
-        /* Check if we have an event stored after this one */
-        off_t lastpos = lseek(fd, 0, SEEK_END);
-        MYASSERT(lastpos >= 0)
-
-        if (lastpos == curpos) {
-            /* EOF, insert this event backward */
-            lseek(fd, lastpos - ev_size, SEEK_SET);
-            write(evdevfds[evnum], &ev, ev_size);
-            lseek(fd, lastpos - ev_size, SEEK_SET);
-            debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote evdev event at offset ", lastpos - ev_size);
-            return;
-        }
-
-        /* Read the next event and check if time match */
-        MYASSERT((lastpos - curpos) >= ev_size)
-        struct input_event next_ev;
-        lseek(fd, curpos, SEEK_SET);
-        read(fd, &next_ev, sizeof(next_ev));
-
-        if (next_ev.time.tv_sec == ev.time.tv_sec && next_ev.time.tv_usec == ev.time.tv_usec) {
-            /* Events are from the same frame, insert this event backward */
-            lseek(fd, curpos - ev_size, SEEK_SET);
-            write(evdevfds[evnum], &ev, ev_size);
-            lseek(fd, curpos - ev_size, SEEK_SET);
-            debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote evdev event at offset ", curpos - ev_size);
-            return;
-        }
-    }
-
-    /* In any other case, insert the event at the end of the file */
-    off_t writepos = lseek(fd, 0, SEEK_END);
-    write(evdevfds[evnum], &ev, ev_size);
-    debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote evdev event at offset ", writepos);
-    lseek(fd, curpos, SEEK_SET);
+    if (evdevfds[evnum][2] != 0)
+        write(evdevfds[evnum][1], &ev, sizeof(ev));
 }
 
 int get_ev_number(int fd)
 {
-    for (int i=0; i<AllInputs::MAXJOYS; i++) {
-        if (evdevfds[i] == fd) {
+    for (int i=0; i<AllInputs::MAXJOYS; i++)
+        if (evdevfds[i][0] == fd)
             return i;
-        }
-    }
     return -1;
 }
 
 
-void close_evdev(int fd)
+int close_evdev(int fd)
 {
     for (int i=0; i<AllInputs::MAXJOYS; i++) {
-        if (evdevfds[i] == fd) {
-            evdevfds[i] = 0;
+        if (evdevfds[i][0] == fd && evdevfds[i][2] != 0 && --evdevfds[i][2] == 0) {
+            GlobalNative gn;
+            close(evdevfds[i][0]);
+            close(evdevfds[i][1]);
+            return 0;
         }
     }
+    return 1;
 }
 
 }

--- a/src/library/inputs/evdev.h
+++ b/src/library/inputs/evdev.h
@@ -40,7 +40,7 @@ void write_evdev(struct input_event ev, int jsnum);
 int get_ev_number(int fd);
 
 /* Unregister the file descriptor when file is closed */
-void close_evdev(int fd);
+int close_evdev(int fd);
 
 }
 

--- a/src/library/inputs/evdev.h
+++ b/src/library/inputs/evdev.h
@@ -34,7 +34,10 @@ int is_evdev(const char* source);
 int open_evdev(const char* source, int flags);
 
 /* Write an input event in the file */
-void write_evdev(struct input_event ev, int jsnum);
+void write_evdev(struct input_event ev, int evnum);
+
+/* Block, waiting for the input event queue to become empty */
+void sync_evdev(int evnum);
 
 /* Get the joystick number from the file descriptor */
 int get_ev_number(int fd);

--- a/src/library/inputs/evdev.h
+++ b/src/library/inputs/evdev.h
@@ -40,7 +40,7 @@ void write_evdev(struct input_event ev, int jsnum);
 int get_ev_number(int fd);
 
 /* Unregister the file descriptor when file is closed */
-int close_evdev(int fd);
+bool unref_evdev(int fd);
 
 }
 

--- a/src/library/inputs/inputevents.h
+++ b/src/library/inputs/inputevents.h
@@ -42,6 +42,9 @@ void generateMouseMotionEvents(void);
 /* Same as above with the MouseButton event */
 void generateMouseButtonEvents(void);
 
+/* Ensure that the game will receive any events on the next frame */
+void syncEvents(void);
+
 }
 
 #endif

--- a/src/library/inputs/ioctl_joy.cpp
+++ b/src/library/inputs/ioctl_joy.cpp
@@ -21,6 +21,7 @@
 #include "../logging.h"
 #include "../hook.h"
 #include "evdev.h" // get_ev_number
+#include "jsdev.h" // get_js_number
 #include "inputs.h" // game_ai
 #include "../../shared/SingleInput.h"
 #include <linux/joystick.h>
@@ -196,6 +197,8 @@ int ioctl(int fd, unsigned long request, ...) throw()
 
         /* Get the joystick number from the file descriptor */
         int jsnum = get_ev_number(fd);
+        if (jsnum < 0)
+            jsnum = get_js_number(fd);
         if (jsnum < 0) {
             errno = ENOTTY;
             return -1;
@@ -313,6 +316,8 @@ int ioctl(int fd, unsigned long request, ...) throw()
 
             /* Get the joystick number from the file descriptor */
             int jsnum = get_ev_number(fd);
+            if (jsnum < 0)
+                jsnum = get_js_number(fd);
             if (jsnum < 0) {
                 debuglog(LCF_JOYSTICK, "   joystick not found!");
                 errno = ENOTTY;

--- a/src/library/inputs/jsdev.cpp
+++ b/src/library/inputs/jsdev.cpp
@@ -25,18 +25,17 @@
 #include "../../shared/AllInputs.h"
 #include "../../shared/SingleInput.h"
 #include <unistd.h>
-#include <sys/syscall.h>
 
 namespace libtas {
 
-static int jsdevfds[AllInputs::MAXJOYS] = {0};
+/* The subarray contains pipe in fd, pipe out fd, and refcount. */
+static int jsdevfds[AllInputs::MAXJOYS][3] = {{0}};
 
 int is_jsdev(const char* source)
 {
     /* Extract the js number from the dev filename */
     int jsnum;
     int ret = sscanf(source, "/dev/input/js%d", &jsnum);
-
     if (ret != 1)
         return -1;
 
@@ -62,121 +61,53 @@ int open_jsdev(const char* source, int flags)
 
     debuglog(LCF_JOYSTICK, "   jsdev device ", jsnum, " detected");
 
-    if (jsdevfds[jsnum] != 0) {
-        debuglog(LCF_JOYSTICK | LCF_ERROR, "Warning, jsdev ", source, " opened multiple times!");
+    if (jsdevfds[jsnum][2]++ == 0) {
+        /* Register that we use JSDEV for joystick inputs */
+        game_info.joystick = GameInfo::JSDEV;
+        game_info.tosend = true;
+
+        /* Create an unnamed pipe */
+        MYASSERT(pipe(jsdevfds[jsnum]) == 0);
+
+        /* Write the synthetic events corresponding to the initial state of the
+         * joystick. */
+        struct js_event ev;
+
+        struct timespec ts = detTimer.getTicks();
+        ev.time = ts.tv_sec*1000 + ts.tv_nsec/1000000;
+        ev.value = 0;
+        for (int button = 0; button < 11; button++) {
+            ev.type = JS_EVENT_BUTTON | JS_EVENT_INIT;
+            ev.number = button;
+            write_jsdev(ev, jsnum);
+        }
+        for (int axis = 0; axis < 8; axis++) {
+            ev.type = JS_EVENT_AXIS | JS_EVENT_INIT;
+            ev.number = axis;
+            write_jsdev(ev, jsnum);
+        }
     }
 
-    /* Register that we use JSDEV for joystick inputs */
-    game_info.joystick = GameInfo::JSDEV;
-    game_info.tosend = true;
-
-    /* Create an anonymous file and store its file descriptor using the
-     * recent memfd_create syscall.
-     */
-    int fd = syscall(SYS_memfd_create, source, 0);
-    jsdevfds[jsnum] = fd;
-
-    /* Write the synthetic events corresponding to the initial state of the
-     * joystick. */
-    struct js_event ev;
-
-    struct timespec ts = detTimer.getTicks();
-    ev.time = ts.tv_sec*1000 + ts.tv_nsec/1000000;
-    ev.value = 0;
-    for (int button = 0; button < 11; button++) {
-        ev.type = JS_EVENT_BUTTON | JS_EVENT_INIT;
-        ev.number = button;
-        write_jsdev(ev, jsnum);
-    }
-    for (int axis = 0; axis < 8; axis++) {
-        ev.type = JS_EVENT_AXIS | JS_EVENT_INIT;
-        ev.number = axis;
-        write_jsdev(ev, jsnum);
-    }
-
-    return fd;
+    return jsdevfds[jsnum][0];;
 }
 
 void write_jsdev(struct js_event ev, int jsnum)
 {
-    int fd = jsdevfds[jsnum];
-
-    if (fd == 0)
-        return;
-
-    /* We must simulate a queue using our memfd structure (basically a file).
-     * Of course, we must not grow our file too much.
-     * One thing that helps us is that we can insert events of the same frame
-     * at any order. To acheive that, we insert the event backward from
-     * the file position if the next event is from the same frame (or eof).
-     *
-     *    <---------------------|~~~~~~~~~~~~~~~~~~~|------------------------>
-     *            read         new       new       old         unread
-     *                       position   event    position
-     *
-     * For any other case, we append at the end.
-     *
-     *    <|---------------------------------------------------|+++++++++++++>
-     *  old/new                 unread                            new event
-     *  position
-     *
-     */
-
-    off_t curpos = lseek(fd, 0, SEEK_CUR);
-    MYASSERT(curpos >= 0)
-
-    off_t jsev_size = static_cast<off_t>(sizeof(struct js_event));
-
-    if (curpos > 0) {
-        MYASSERT(curpos >= jsev_size)
-
-        /* Check if we have an event stored after this one */
-        off_t lastpos = lseek(fd, 0, SEEK_END);
-        MYASSERT(lastpos >= 0)
-
-        if (lastpos == curpos) {
-            /* EOF, insert this event backward */
-            lseek(fd, lastpos - jsev_size, SEEK_SET);
-            write(jsdevfds[jsnum], &ev, jsev_size);
-            lseek(fd, lastpos - jsev_size, SEEK_SET);
-            debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote jsdev event at offset ", lastpos - jsev_size);
-            return;
-        }
-
-        /* Read the next event and check if time match */
-        MYASSERT((lastpos - curpos) >= jsev_size)
-        struct js_event next_ev;
-        lseek(fd, curpos, SEEK_SET);
-        read(fd, &next_ev, sizeof(next_ev));
-
-        if (next_ev.time == ev.time) {
-            /* Events are from the same frame, insert this event backward */
-            lseek(fd, curpos - jsev_size, SEEK_SET);
-            write(jsdevfds[jsnum], &ev, jsev_size);
-            lseek(fd, curpos - jsev_size, SEEK_SET);
-            debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote jsdev event at offset ", curpos - jsev_size);
-            return;
-        }
-    }
-
-    /* In any other case, insert the event at the end of the file */
-    off_t writepos = lseek(fd, 0, SEEK_END);
-    write(jsdevfds[jsnum], &ev, jsev_size);
-    debuglog(LCF_JOYSTICK | LCF_EVENTS, "    Wrote jsdev event at offset ", writepos);
-    lseek(fd, curpos, SEEK_SET);
+    if (jsdevfds[jsnum][2] != 0)
+        write(jsdevfds[jsnum][1], &ev, sizeof(ev));
 }
 
-void close_jsdev(int fd)
+int close_jsdev(int fd)
 {
     for (int i=0; i<AllInputs::MAXJOYS; i++) {
-        if (jsdevfds[i] == fd) {
-            jsdevfds[i] = 0;
-            //return close(fd);
+        if (jsdevfds[i][0] == fd && jsdevfds[i][2] != 0 && --jsdevfds[i][2] == 0) {
+            GlobalNative gn;
+            close(jsdevfds[i][0]);
+            close(jsdevfds[i][1]);
+            return 0;
         }
     }
-
-//    debuglog(LCF_JOYSTICK | LCF_ERROR, "Could not find the joyfd to close!");
-//    return close(fd);
+    return 1;
 }
 
 }

--- a/src/library/inputs/jsdev.cpp
+++ b/src/library/inputs/jsdev.cpp
@@ -97,6 +97,14 @@ void write_jsdev(struct js_event ev, int jsnum)
         write(jsdevfds[jsnum][1], &ev, sizeof(ev));
 }
 
+int get_js_number(int fd)
+{
+    for (int i=0; i<AllInputs::MAXJOYS; i++)
+        if (jsdevfds[i][0] == fd)
+            return i;
+    return -1;
+}
+
 int close_jsdev(int fd)
 {
     for (int i=0; i<AllInputs::MAXJOYS; i++) {

--- a/src/library/inputs/jsdev.cpp
+++ b/src/library/inputs/jsdev.cpp
@@ -94,8 +94,29 @@ int open_jsdev(const char* source, int flags)
 
 void write_jsdev(struct js_event ev, int jsnum)
 {
-    if (jsdevfds[jsnum].second != 0)
-        write(jsdevfds[jsnum].first.second, &ev, sizeof(ev));
+    if (jsdevfds[jsnum].second == 0)
+        return;
+
+    write(jsdevfds[jsnum].first.second, &ev, sizeof(ev));
+}
+
+void sync_jsdev(int jsnum)
+{
+    if (jsdevfds[jsnum].second == 0)
+        return;
+
+    int attempts = 0, count = 0;
+    do {
+        ioctl(jsdevfds[jsnum].first.first, FIONREAD, &count);
+        if (count > 0) {
+            if (++attempts > 10 * 100) {
+                debuglog(LCF_JOYSTICK | LCF_ERROR | LCF_ALERT, "jsdev sync took too long, were asynchronous events incorrectly enabled?");
+                return;
+            }
+            struct timespec sleepTime = { 0, 10 * 1000 };
+            NATIVECALL(nanosleep(&sleepTime, NULL));
+        }
+    } while (count > 0);
 }
 
 int get_js_number(int fd)

--- a/src/library/inputs/jsdev.h
+++ b/src/library/inputs/jsdev.h
@@ -37,7 +37,7 @@ int open_jsdev(const char* source, int flags);
 void write_jsdev(struct js_event ev, int jsnum);
 
 /* Unregister the file descriptor when file is closed */
-void close_jsdev(int fd);
+int close_jsdev(int fd);
 
 }
 

--- a/src/library/inputs/jsdev.h
+++ b/src/library/inputs/jsdev.h
@@ -40,7 +40,7 @@ void write_jsdev(struct js_event ev, int jsnum);
 int get_js_number(int fd);
 
 /* Unregister the file descriptor when file is closed */
-int close_jsdev(int fd);
+bool unref_jsdev(int fd);
 
 }
 

--- a/src/library/inputs/jsdev.h
+++ b/src/library/inputs/jsdev.h
@@ -36,6 +36,9 @@ int open_jsdev(const char* source, int flags);
 /* Write an js event in the file */
 void write_jsdev(struct js_event ev, int jsnum);
 
+/* Get the joystick number from the file descriptor */
+int get_js_number(int fd);
+
 /* Unregister the file descriptor when file is closed */
 int close_jsdev(int fd);
 

--- a/src/library/inputs/jsdev.h
+++ b/src/library/inputs/jsdev.h
@@ -36,6 +36,9 @@ int open_jsdev(const char* source, int flags);
 /* Write an js event in the file */
 void write_jsdev(struct js_event ev, int jsnum);
 
+/* Block, waiting for the js event queue to become empty */
+void sync_jsdev(int jsnum);
+
 /* Get the joystick number from the file descriptor */
 int get_js_number(int fd);
 

--- a/src/library/logging.h
+++ b/src/library/logging.h
@@ -106,11 +106,11 @@ inline void debuglog(LogCategoryFlag lcf, Args ...args)
 }
 
 /* If we only want to print the function name... */
-#define DEBUGLOGCALL(lcf) libtas::debuglogstdio(lcf, "%s call.", __func__)
+#define DEBUGLOGCALL(lcf) debuglogstdio(lcf, "%s call.", __func__)
 
 /* Macro of an assert */
 #define MYASSERT(term) if ((term)) {} \
-    else {libtas::debuglogstdio(LCF_ERROR, "%s failed in %s", #term, __func__); \
+    else {debuglogstdio(LCF_ERROR, "%s failed in %s", #term, __func__); \
     exit(1);}
 
 /* We want to store and send error messages to the program so that they can be

--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -135,6 +135,7 @@ void Config::save(const std::string& gamepath) {
     settings.setValue("locale", sc.locale);
     settings.setValue("virtual_steam", sc.virtual_steam);
     settings.setValue("opengl_soft", sc.opengl_soft);
+    settings.setValue("async_events", sc.async_events);
 
     settings.beginWriteArray("main_gettimes_threshold");
     for (int t=0; t<SharedConfig::TIMETYPE_NUMTRACKEDTYPES; t++) {
@@ -256,6 +257,7 @@ void Config::load(const std::string& gamepath) {
     sc.audio_mute = settings.value("audio_mute", sc.audio_mute).toBool();
     sc.locale = settings.value("locale", sc.locale).toInt();
     sc.virtual_steam = settings.value("virtual_steam", sc.virtual_steam).toBool();
+    sc.async_events = settings.value("async_events", sc.async_events).toBool();
 
     sc.video_codec = settings.value("video_codec", sc.video_codec).toInt();
     sc.video_bitrate = settings.value("video_bitrate", sc.video_bitrate).toInt();

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -690,6 +690,9 @@ void MainWindow::createMenus()
     steamAction = runtimeMenu->addAction(tr("Virtual Steam client"), this, &MainWindow::slotSteam);
     steamAction->setCheckable(true);
     disabledActionsOnStart.append(steamAction);
+    asyncEventsAction = runtimeMenu->addAction(tr("Asynchronous events"), this, &MainWindow::slotAsyncEvents);
+    asyncEventsAction->setCheckable(true);
+    disabledActionsOnStart.append(asyncEventsAction);
 
     QMenu *debugMenu = runtimeMenu->addMenu(tr("Debug"));
 
@@ -1082,6 +1085,7 @@ void MainWindow::updateUIFromConfig()
     preventSavefileAction->setChecked(context->config.sc.prevent_savefiles);
     recycleThreadsAction->setChecked(context->config.sc.recycle_threads);
     steamAction->setChecked(context->config.sc.virtual_steam);
+    asyncEventsAction->setChecked(context->config.sc.async_events);
 
     incrementalStateAction->setChecked(context->config.sc.incremental_savestates);
     ramStateAction->setChecked(context->config.sc.savestates_in_ram);
@@ -1458,6 +1462,7 @@ BOOLSLOT(slotSaveScreen, context->config.sc.save_screenpixels)
 BOOLSLOT(slotPreventSavefile, context->config.sc.prevent_savefiles)
 BOOLSLOT(slotRecycleThreads, context->config.sc.recycle_threads)
 BOOLSLOT(slotSteam, context->config.sc.virtual_steam)
+BOOLSLOT(slotAsyncEvents, context->config.sc.async_events)
 
 void MainWindow::slotMovieEnd()
 {

--- a/src/program/ui/MainWindow.h
+++ b/src/program/ui/MainWindow.h
@@ -107,6 +107,7 @@ public:
     QAction *ramStateAction;
     QAction *backtrackStateAction;
     QAction *steamAction;
+    QAction *asyncEventsAction;
 
     QActionGroup *debugStateGroup;
     QActionGroup *loggingOutputGroup;
@@ -275,6 +276,7 @@ private slots:
     void slotBacktrackState(bool checked);
     void slotRecycleThreads(bool checked);
     void slotSteam(bool checked);
+    void slotAsyncEvents(bool checked);
     void slotCalibrateMouse();
     void slotAutoRestart(bool checked);
 };

--- a/src/shared/SharedConfig.h
+++ b/src/shared/SharedConfig.h
@@ -215,6 +215,9 @@ struct SharedConfig {
     /* Force Mesa software OpenGL driver */
     bool opengl_soft = true;
 
+    /* Wait for events to be processed in a separate thread before starting frame */
+    bool async_events = false;
+
 };
 
 #endif


### PR DESCRIPTION
I was getting a reproducible issue where loading a save state would cause the game to receive incorrect joystick inputs.  I didn't debug the issue too much, but I suspect it is because checkpoints don't save and restore fd offsets.  However, using pipes is much cleaner and fixes the issue anyway.  Also, support evdev ioctls on the corresponding jsdev, because I saw a game trying to use one of the implemented ioctls on the jsdev.