### PR TITLE
Option to prevent the frame counter from advancing on frames with no delay

### DIFF
--- a/src/library/DeterministicTimer.cpp
+++ b/src/library/DeterministicTimer.cpp
@@ -101,7 +101,9 @@ struct timespec DeterministicTimer::getTicks(SharedConfig::TimeCallType type)
     if (ticksExtra) {
         /* Delay by ticksExtra ms. Arbitrary */
         struct timespec delay = {0, ticksExtra * 1000000};
+        bool oldSleepCalled = sleepCalled; /* Avoid generating spurious vsync frames */
         addDelay(delay);
+        sleepCalled = oldSleepCalled;
     }
 
     TimeHolder fakeTicks = ticks + fakeExtraTicks;

--- a/src/library/DeterministicTimer.cpp
+++ b/src/library/DeterministicTimer.cpp
@@ -112,6 +112,8 @@ void DeterministicTimer::addDelay(struct timespec delayTicks)
 {
     debuglog(LCF_TIMESET | LCF_SLEEP, __func__, " call with delay ", delayTicks.tv_sec * 1000000000 + delayTicks.tv_nsec, " nsec");
 
+    sleepCalled = true;
+
     if (shared_config.debug_state & SharedConfig::DEBUG_UNCONTROLLED_TIME)
         return nonDetTimer.addDelay(delayTicks);
 
@@ -213,6 +215,7 @@ void DeterministicTimer::enterFrameBoundary()
     DEBUGLOGCALL(LCF_TIMEGET);
 
     insideFrameBoundary = true;
+    sleepCalled = false;
 
     if (shared_config.debug_state & SharedConfig::DEBUG_UNCONTROLLED_TIME)
         return nonDetTimer.enterFrameBoundary();

--- a/src/library/DeterministicTimer.h
+++ b/src/library/DeterministicTimer.h
@@ -56,7 +56,7 @@ public:
     struct timespec getTicks(SharedConfig::TimeCallType type);
 
     /* Returns true if the current frame boundary is acceptable for require_vsync mode */
-    bool isFrameBoundary() { return insideFrameBoundary || sleepCalled; }
+    bool isFrameBoundary();
 
     /* Function called when entering a frame boundary */
     void enterFrameBoundary(void);

--- a/src/library/DeterministicTimer.h
+++ b/src/library/DeterministicTimer.h
@@ -65,7 +65,7 @@ public:
     void exitFrameBoundary(void);
 
     /* Add a delay in the timer, and sleep */
-    void addDelay(struct timespec delayTicks);
+    void addDelay(struct timespec delayTicks, bool isSynthesized = false);
 
     /* Flush the accumulated timer delay. Used when game is exiting */
     void flushDelay();

--- a/src/library/DeterministicTimer.h
+++ b/src/library/DeterministicTimer.h
@@ -55,6 +55,9 @@ public:
     struct timespec getTicks();
     struct timespec getTicks(SharedConfig::TimeCallType type);
 
+    /* Returns true if the current frame boundary is acceptable for require_vsync mode */
+    bool isFrameBoundary() { return insideFrameBoundary || sleepCalled; }
+
     /* Function called when entering a frame boundary */
     void enterFrameBoundary(void);
 
@@ -62,10 +65,10 @@ public:
     void exitFrameBoundary(void);
 
     /* Add a delay in the timer, and sleep */
-	void addDelay(struct timespec delayTicks);
+    void addDelay(struct timespec delayTicks);
 
     /* Flush the accumulated timer delay. Used when game is exiting */
-	void flushDelay();
+    void flushDelay();
 
     /* In specific situations, we must fake advancing timer.
      * This function temporarily fake adding ticks to the timer.
@@ -113,8 +116,11 @@ private:
     int main_gettimes[SharedConfig::TIMETYPE_NUMTRACKEDTYPES];
     int sec_gettimes[SharedConfig::TIMETYPE_NUMTRACKEDTYPES];
 
-    /* Are we inside a frame boudary */
+    /* Are we inside a frame boundary */
     bool insideFrameBoundary = false;
+
+    /* Was sleep called at all since the last frame boundary */
+    bool sleepCalled = false;
 
     /* Mutex to protect access to the ticks value */
     std::mutex mutex;

--- a/src/library/frame.cpp
+++ b/src/library/frame.cpp
@@ -187,6 +187,7 @@ void frameBoundary(bool drawFB, std::function<void()> draw, bool restore_screen)
 
     /* Make sure we actually want to advance the frame counter */
     if (shared_config.require_vsync && !detTimer.isFrameBoundary()) {
+        detTimer.flushDelay();
         NATIVECALL(draw());
         return;
     }

--- a/src/library/frame.cpp
+++ b/src/library/frame.cpp
@@ -185,6 +185,12 @@ void frameBoundary(bool drawFB, std::function<void()> draw, bool restore_screen)
         return;
     }
 
+    /* Make sure we actually want to advance the frame counter */
+    if (shared_config.require_vsync && !detTimer.isFrameBoundary()) {
+        NATIVECALL(draw());
+        return;
+    }
+
     /*** Update time ***/
 
     /* First, increase the frame count */

--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -137,6 +137,7 @@ void Config::save(const std::string& gamepath) {
     settings.setValue("opengl_soft", sc.opengl_soft);
     settings.setValue("async_events", sc.async_events);
     settings.setValue("wait_timeout", sc.wait_timeout);
+    settings.setValue("require_vsync", sc.require_vsync);
 
     settings.beginWriteArray("main_gettimes_threshold");
     for (int t=0; t<SharedConfig::TIMETYPE_NUMTRACKEDTYPES; t++) {
@@ -253,6 +254,7 @@ void Config::load(const std::string& gamepath) {
     sc.virtual_steam = settings.value("virtual_steam", sc.virtual_steam).toBool();
     sc.async_events = settings.value("async_events", sc.async_events).toInt();
     sc.wait_timeout = settings.value("wait_timeout", sc.wait_timeout).toInt();
+    sc.require_vsync = settings.value("require_vsync", sc.require_vsync).toBool();
 
     sc.video_codec = settings.value("video_codec", sc.video_codec).toInt();
     sc.video_bitrate = settings.value("video_bitrate", sc.video_bitrate).toInt();

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -733,6 +733,10 @@ void MainWindow::createMenus()
     disabledWidgetsOnStart.append(asyncMenu);
     asyncMenu->addActions(asyncGroup->actions());
 
+    requireVsyncAction = runtimeMenu->addAction(tr("Require vsync to advance frame"), this, &MainWindow::slotRequireVsync);
+    requireVsyncAction->setCheckable(true);
+    disabledActionsOnStart.append(requireVsyncAction);
+
     QMenu *debugMenu = runtimeMenu->addMenu(tr("Debug"));
 
     debugMenu->addActions(debugStateGroup->actions());
@@ -1144,6 +1148,7 @@ void MainWindow::updateUIFromConfig()
     recycleThreadsAction->setChecked(context->config.sc.recycle_threads);
     steamAction->setChecked(context->config.sc.virtual_steam);
     setCheckboxesFromMask(asyncGroup, context->config.sc.async_events);
+    requireVsyncAction->setChecked(context->config.sc.require_vsync);
 
     incrementalStateAction->setChecked(context->config.sc.incremental_savestates);
     ramStateAction->setChecked(context->config.sc.savestates_in_ram);
@@ -1521,6 +1526,7 @@ BOOLSLOT(slotPreventSavefile, context->config.sc.prevent_savefiles)
 BOOLSLOT(slotRecycleThreads, context->config.sc.recycle_threads)
 BOOLSLOT(slotSteam, context->config.sc.virtual_steam)
 BOOLSLOT(slotAsyncEvents, context->config.sc.async_events)
+BOOLSLOT(slotRequireVsync, context->config.sc.require_vsync)
 
 void MainWindow::slotMovieEnd()
 {

--- a/src/program/ui/MainWindow.h
+++ b/src/program/ui/MainWindow.h
@@ -107,6 +107,7 @@ public:
     QAction *ramStateAction;
     QAction *backtrackStateAction;
     QAction *steamAction;
+    QAction *requireVsyncAction;
     QActionGroup *waitGroup;
     QActionGroup *asyncGroup;
 
@@ -279,6 +280,7 @@ private slots:
     void slotRecycleThreads(bool checked);
     void slotSteam(bool checked);
     void slotAsyncEvents(bool checked);
+    void slotRequireVsync(bool checked);
     void slotCalibrateMouse();
     void slotAutoRestart(bool checked);
 };

--- a/src/shared/SharedConfig.h
+++ b/src/shared/SharedConfig.h
@@ -238,6 +238,9 @@ struct SharedConfig {
     /* How are we handling waits */
     int wait_timeout = WAIT_NATIVE;
 
+    /* Require vsync or sleep to advance the frame counter */
+    bool require_vsync = false;
+
 };
 
 #endif


### PR DESCRIPTION
Currently does not handle GPU-based vsync (only sleep-based vsync).

If GPU-based vsync is needed, it can be implemented by adding zero seconds to the deterministic timer before the call to `frameBoundary`.

This seems to work as-is with Undertale and Deltarune. The time tracking option (`clock_gettime`) is still required to prevent the game from hard-locking at startup.

Sleeps generated by time tracking options do not count towards vsync frames.