### PR TITLE
Fix build error when LIBTAS_HAS_XINPUT not defined

### DIFF
--- a/src/library/XlibEventQueue.cpp
+++ b/src/library/XlibEventQueue.cpp
@@ -205,6 +205,7 @@ void XlibEventQueue::delayedDeleteCookie(XEvent* event)
     else {
         cookieData = nullptr;
     }
-}
 #endif
+}
+
 }


### PR DESCRIPTION
When LIBTAS_HAS_XINPUT isn't defined, the build failed due to mismatched brackets. 

I initially bumped into this while trying to figure out how to cross-compile the 32-bit version on my 64-bit system without resorting to a VM. 

Apparently my attempt at a 32-bit build exposed it due me to apparently not having the 32-bit version of Xinput installed. Which caused the contents of the ifdef block to be omitted, which caused a mismatched bracket to fail the build.

It looks like the idea here is that if we don't have Xinput, then the function becomes a no-op in the form of an empty `{}` block. But the closing bracket was on the wrong side of the `#endif` for that to work. The confusion is probably related to that other `}` bracket outside the `ifdef` block, but that thing is actually to close the `namespace` block that starts all the way up on line 27.