### PR TITLE
Exterminate Zombie Outbreak (fixes #209)

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -1413,7 +1413,11 @@ void GameLoop::loopExit()
 
         /* Remove savestates because they are invalid on future instances of the game */
         remove_savestates(context);
-
+        
+        /* wait on the previous process one last time to try to prevent it leaving a zombie */
+        usleep(50*1000);
+        waitpid(context->game_pid, nullptr, WNOHANG);
+        
         context->status = Context::RESTARTING;
         emit statusChanged();
 
@@ -1442,6 +1446,10 @@ void GameLoop::loopExit()
     /* Remove savestates because they are invalid on future instances of the game */
     remove_savestates(context);
 
+    /* wait on the previous process one last time to try to prevent it leaving a zombie */
+        usleep(50*1000);
+        waitpid(context->game_pid, nullptr, WNOHANG);
+        
     context->status = Context::INACTIVE;
     emit statusChanged();
 }


### PR DESCRIPTION
see #209 

libTAS was leaving behind a zombie process every time it closed the game, and they weren't getting reaped until libTAS itself was closed. Adding a couple waits into the loopExit function solved this problem.

I just copied the `waitpid(context->game_pid, nullptr, WNOHANG);` function call from elsewhere in the file, where it was being used to check for abnormal termination. Now it's being called during normal termination also, with its return value ignored.

I guess I could have used a different `wait()` variant, one that actually waits for the process instead of being non-blocking, but I didn't want to risk introducing a hang just to fix a relatively harmless resource leak. This seems to solve it anyway.