### PR TITLE
Set up compiler optimizations for Release build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,10 @@ target_compile_options(tas PUBLIC -fvisibility=hidden)
 target_compile_options(libTAS PUBLIC -Wno-float-equal)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}  -Wall -Wextra -Wmissing-include-dirs -Wmissing-declarations -Wfloat-equal -Wundef -Wcast-align -Winit-self -Wshadow -Wno-unused-parameter -Wno-missing-field-initializers")
 
+# Set optimization flags for release
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -fweb -flto=1 -fno-stack-protector")
+set(CMAKE_CFLAGS_RELEASE "-O2 -DNDEBUG -fweb -flto=1 -fno-stack-protector")
+
 # Add Qt5 lib
 find_package(Qt5Widgets REQUIRED)
 if (Qt5Widgets_FOUND)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To enable HUD on the game screen, you will also need:
 ### Building
 
     mkdir build && cd build
-    cmake ..
+    cmake -DCMAKE_BUILD_TYPE=Release ..
     make
 
 Cmake will detect the presence of these libraries and disable the corresponding features if necessary.

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 
 # dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+
+# Use target Release instead of None
+override_dh_auto_configure:
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release

--- a/debian/rules
+++ b/debian/rules
@@ -5,13 +5,18 @@ export DH_VERBOSE = 1
 
 
 # see FEATURE AREAS in dpkg-buildflags(1)
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_MAINT_OPTIONS = hardening=-all
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS
 export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
+#disable building debugging symbols
+export DEB_CFLAGS_MAINT_STRIP  = -g 
+export DEB_CXXFLAGS_MAINT_STRIP  = -g 
+export DEB_LDFLAGS_MAINT_STRIP = -g 
 
 
 %:


### PR DESCRIPTION
I noticed that the build system didn't really seem to be set up to take advantage of compiler optimizations. So here's my attempt at enabling some of them, hopefully this will be good for performance.

This PR sets the `CFLAGS` for Release mode, updates `README.md` to recommend building in Release mode instead of default mode, and also sets `debian/rules` to use Release mode (apparently it wasn't by default).

The default Release flags, when not specifically set, seem to be "`-O3 -DNDEBUG`" (although these weren't being used, because it was never being built in Release mode).

I set CMakeLists.txt to override the release flags with "`-O2 -DNDEBUG -fweb -flto=1 -fno-stack-protector`"

- I downgraded `-O3` to `-O2` because I'm not entirely sure the former is safe. The latter, on the other hand, I'm pretty sure _is_ safe, especially because it was apparently (according to Appveyor logs) already being enabled on all the .deb packages due to debhelper turning it on by default. So that flag has effectively already been very-well-tested.

- I enabled `-fweb` because it's supposed to make other optimizations more effective, with the only downside being that it can hamper debugging. Since the Release flags aren't enabled when building in Debug mode, that shouldn't be an issue.
  - I'm assuming that to mean it makes the program itself harder to debug, not prevents it from functioning like a debugger. But I guess you could turn it off if that were concerning.

- I enabled `-flto` , Link Time Optimization. By doing the optimization during linking instead of during compiling, the other optimizations can work over the whole program or library instead of just individual .cpp files, making them a lot more effective. The reason it's not turned on by default is that if you're building a really large project, the build can take too long and use way too much memory. But that doesn't seem to be a problem for libTAS.

- I set `-fno-stack-protector` to turn off stack smashing protection. On some distro's packaged versions of GCC (Ubuntu's, for example) SSP is enabled by default, but it can carry a performance penalty and really shouldn't be necessary for any program that doesn't expect to be targeted by a stack smashing exploit. 
  - On versions of GCC that _don't_ enable SSP by default, setting the flag to specifically disable it is redundant but harmless.