### PR TITLE
add support for automatically merging encode segments via helper script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,8 +292,14 @@ else()
     message(WARNING "HUD is disabled")
 endif()
 
+#add helper script to build directory.
+configure_file(libTasConcat.sh ./libTasConcat.sh COPYONLY)
+
 # Install program and library
 install(TARGETS libTAS tas DESTINATION bin)
+
+# Install dump segment automerge helper script
+install(FILES libTasConcat.sh DESTINATION bin)
 
 # Install desktop entry
 install(FILES libTAS.desktop DESTINATION share/applications)

--- a/libTasConcat.sh
+++ b/libTasConcat.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# absolute path to the first video (eg. /home/user/tasproject01/video.avi) is passed as command line argument 1
+
+VID_PATH=$1
+VID_EXT=$(echo $VID_PATH | sed 's/^.*\././g')
+VID_DIR=$(dirname $VID_PATH)
+VID_NAME=$(basename -s $VID_EXT $VID_PATH)
+
+getChunks(){
+    #first video is a special case
+    echo file $VID_PATH
+    
+    #sort command can ensure the rest are in order
+    temp_var="$VID_DIR"/"$VID_NAME"_
+    for i in $(sort -nk 1.$(( ${#temp_var} + 1))  <(ls -1 "$VID_DIR"/"$VID_NAME"_*"$VID_EXT"))
+    do
+      echo file $i
+    done
+}
+
+sync
+yes | ffmpeg -f concat -safe 0 -i <(getChunks) -c copy $VID_DIR/$VID_NAME-merged.mkv

--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -78,6 +78,7 @@ void Config::save(const std::string& gamepath) {
     settings.setValue("autosave_frames", autosave_frames);
     settings.setValue("autosave_count", autosave_count);
     settings.setValue("auto_restart", auto_restart);
+    settings.setValue("merge_dump_segments", merge_dump_segments);
 
     settings.beginGroup("keymapping");
 
@@ -195,6 +196,7 @@ void Config::load(const std::string& gamepath) {
     autosave_frames = settings.value("autosave_frames", autosave_frames).toInt();
     autosave_count = settings.value("autosave_count", autosave_count).toInt();
     auto_restart = settings.value("auto_restart", auto_restart).toBool();
+    merge_dump_segments = settings.value("merge_dump_segments", merge_dump_segments).toBool();
 
     /* Load key mapping */
 

--- a/src/program/Config.h
+++ b/src/program/Config.h
@@ -63,6 +63,9 @@ public:
 
     /* Were we started up with the -d option? */
     bool dumping;
+    
+    /* Were we started up with the -d option? */
+    bool merge_dump_segments = false;
 
     /* Path of the libraries used by the game */
     std::string libdir;

--- a/src/program/GameLoop.h
+++ b/src/program/GameLoop.h
@@ -91,6 +91,8 @@ private:
     bool haveFocus();
 
     void loopExit();
+    
+    void mergeSegments();
 
 signals:
     void statusChanged();

--- a/src/program/ui/EncodeWindow.cpp
+++ b/src/program/ui/EncodeWindow.cpp
@@ -71,6 +71,9 @@ EncodeWindow::EncodeWindow(Context* c, QWidget *parent, Qt::WindowFlags flags) :
     connect(audioBitrate, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EncodeWindow::slotUpdate);
 
     ffmpegOptions = new QLineEdit();
+    
+    mergeCheck = new QCheckBox("Automatically merge dump segments");
+    connect(mergeCheck, &QAbstractButton::clicked, this, &EncodeWindow::slotMerge);
 
     QGroupBox *codecGroupBox = new QGroupBox(tr("Encode codec settings"));
     QGridLayout *encodeCodecLayout = new QGridLayout;
@@ -86,6 +89,8 @@ EncodeWindow::EncodeWindow(Context* c, QWidget *parent, Qt::WindowFlags flags) :
 
     encodeCodecLayout->addWidget(new QLabel(tr("ffmpeg options:")), 2, 0);
     encodeCodecLayout->addWidget(ffmpegOptions, 2, 1, 1, 4);
+    encodeCodecLayout->addWidget(mergeCheck, 3, 1, 1, 4);
+    
 
     encodeCodecLayout->setColumnMinimumWidth(2, 50);
     encodeCodecLayout->setColumnStretch(2, 1);
@@ -128,6 +133,8 @@ void EncodeWindow::update_config()
 
     /* Set ffmpeg options */
     ffmpegOptions->setText(context->config.ffmpegoptions.c_str());
+    
+    mergeCheck->setChecked(context->config.merge_dump_segments);
 
     if (context->config.ffmpegoptions.empty()) {
         slotUpdate();
@@ -166,4 +173,9 @@ void EncodeWindow::slotBrowseEncodePath()
     QString filename = QFileDialog::getSaveFileName(this, tr("Choose an encode filename"), encodePath->text());
     if (!filename.isNull())
         encodePath->setText(filename);
+}
+
+void EncodeWindow::slotMerge(bool checked)
+{
+        context->config.merge_dump_segments = checked;
 }

--- a/src/program/ui/EncodeWindow.h
+++ b/src/program/ui/EncodeWindow.h
@@ -25,6 +25,8 @@
 #include <QLineEdit>
 #include <QComboBox>
 #include <QSpinBox>
+#include <QCheckBox>
+
 
 #include "../Context.h"
 
@@ -47,11 +49,14 @@ private:
     QComboBox *audioChoice;
     QSpinBox *audioBitrate;
     QLineEdit *ffmpegOptions;
+    QCheckBox *mergeCheck;
+
 
 private slots:
     void slotBrowseEncodePath();
     void slotUpdate();
     void slotOk();
+    void slotMerge(bool checked);
 };
 
 #endif


### PR DESCRIPTION
This is in response to #243.

It adds a checkbox to the encode settings window and a boolean to the config structure, and connects them together. When this new setting is enabled, a helper script written in Bash is called to merge all the segments automatically.

For now, the segments are still left intact and not deleted. However, if it's desired to automatically clean up the segments and free up space after writing the merged file, this could be changed just by adding an extra line or two to the Bash script.

It should be noted that the script heavily uses "Bashisms" and won't run on just any generic POSIX shell. You very seldom see a Linux system without Bash installed though, since it's part of the GNU base system, so I don't think of this as introducing a new dependency.