### PR TITLE
configure.ac: Silent Make rules by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_FILES([
  src/library/Makefile
 ])
 AC_CANONICAL_HOST
+AM_SILENT_RULES([yes])
 
 dnl **** Configure options ****
 


### PR DESCRIPTION
Nice little trick that can reduce the command output seen on `make`, can always be switched off with `./configure --disable-silent-rules` or `make V=1` (the reverse is opposite now, too).