### PR TITLE
Always send Window as a 32-bit integer.

### DIFF
--- a/src/library/xwindows.cpp
+++ b/src/library/xwindows.cpp
@@ -100,6 +100,12 @@ Window XCreateSimpleWindow(Display *display, Window parent, int x, int y, unsign
     return w;
 }
 
+void sendXWindow(Window w)
+{
+    uint32_t i = (uint32_t)w;
+    sendData(&i, sizeof(i));
+}
+
 int XDestroyWindow(Display *display, Window w)
 {
     debuglog(LCF_WINDOW, __func__, " called with window ", w);
@@ -112,7 +118,7 @@ int XDestroyWindow(Display *display, Window w)
 
         /* Tells the program we don't have a window anymore to gather inputs */
         sendMessage(MSGB_WINDOW_ID);
-        sendData(&gameXWindow, sizeof(Window));
+        sendXWindow(gameXWindow);
         debuglog(LCF_WINDOW, "Sent X11 window id 0");        
     }
 
@@ -132,7 +138,7 @@ int XMapWindow(Display *display, Window w)
      */
     if ((gameXWindow != 0) && (gameXWindow == w)) {
         sendMessage(MSGB_WINDOW_ID);
-        sendData(&w, sizeof(Window));
+        sendXWindow(w);
         debuglog(LCF_WINDOW, "Sent X11 window id: ", w);
     }
 
@@ -161,7 +167,7 @@ int XMapRaised(Display *display, Window w)
      */
     if (gameXWindow != 0) {
         sendMessage(MSGB_WINDOW_ID);
-        sendData(&w, sizeof(Window));
+        sendXWindow(w);
         debuglog(LCF_WINDOW, "Sent X11 window id: ", w);
     }
 

--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -522,7 +522,10 @@ bool GameLoop::startFrameMessages()
         float fps, lfps;
         switch (message) {
         case MSGB_WINDOW_ID:
-            receiveData(&context->game_window, sizeof(Window));
+        {
+            uint32_t int_window;
+            receiveData(&int_window, sizeof(uint32_t));
+            context->game_window = (Window)int_window;
             if (context->game_window != 0)
             {
                 const static uint32_t values[] = { XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_EXPOSURE };
@@ -533,6 +536,7 @@ bool GameLoop::startFrameMessages()
                 }
             }
             break;
+        }
 
         case MSGB_ALERT_MSG:
             /* Ask the UI thread to display the alert. He is in charge of


### PR DESCRIPTION
The size of the Window type differs on 32-bit and 64-bit X11,
even though Window id values are limited to 32 bits.

Fixes #239