### PR TITLE
Fix crash when SDL_Quit is called before SDLInitSubSystem

### DIFF
--- a/src/library/sdlmain.cpp
+++ b/src/library/sdlmain.cpp
@@ -66,7 +66,6 @@ static Uint32 init_flags = 0;
 
     /* Link function pointers to SDL functions */
     LINK_NAMESPACE_SDLX(SDL_InitSubSystem);
-    LINK_NAMESPACE_SDLX(SDL_Quit);
 
     if (flags & SDL_INIT_TIMER)
         debuglog(LCF_SDL, "    SDL_TIMER enabled.");
@@ -134,6 +133,7 @@ Uint32 SDL_WasInit(Uint32 flags)
 /* Override */ void SDL_Quit()
 {
     DEBUGLOGCALL(LCF_SDL);
+    LINK_NAMESPACE_SDLX(SDL_Quit);
     orig::SDL_Quit();
 }
 


### PR DESCRIPTION
If SDL_Quit is called before SDL_InitSubSystem, orig::SDL_Quit will be
null, causing a crash. Fix this by adding a null-check before calling.

Fixes #228.

An alternative solution would be to initialize orig::SDL_Quit here instead of in SDL_InitSubSystem.