### PR TITLE
Ww/use game arguments from cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,23 @@ missing
 stamp-h1
 .deps
 .dirstamp
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can download the latest stable version of the software in the [Releases](htt
 * `libqt5core5a`, `libqt5gui5`, `libqt5widgets5` with Qt version at least 5.6
 * `libx11-6`, `libxcb1`, `libxcb-keysyms1`, `libxcb-xkb1`, `libxcb-cursor0`
 * `ffmpeg`
+* `file`
 * `libswresample2` or `libswresample3`, `libasound2`
 * `libfontconfig1`, `libfreetype6`
 

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -124,9 +124,13 @@ int main(int argc, char **argv)
     }
 
     /* Game arguments */
-    for (int i = optind+1; i < argc; i++) {
-        context.config.gameargs += argv[i];
-        context.config.gameargs += " ";
+    std::string gameargsoverride;
+    if (optind + 1 < argc) {
+        gameargsoverride = argv[optind + 1];
+    }
+    for (int i = optind+2; i < argc; i++) {
+        gameargsoverride += " ";
+        gameargsoverride += argv[i];
     }
 
     /* Open connection with the server */
@@ -207,6 +211,9 @@ int main(int argc, char **argv)
 
     /* Now that we have the config dir, we load the game-specific config */
     context.config.load(context.gamepath);
+    if (! gameargsoverride.empty()) {
+        context.config.gameargs = gameargsoverride;
+    }
 
     /* Overwrite the movie path if specified in commandline */
     if (! moviefile.empty()) {


### PR DESCRIPTION
> vim gitignores

> Note dependency on file binary
>
> See extractBinaryType.  Host systems typically have it, but base OS docker images perhaps don't.

> Buffer CLI gameargs and add to config after load
>
> Only if any are passed.  Otherwise they are dropped on the floor.
> 
> This will cause them to also eventually overwrite the gameargs in the game's config ini.  Perhaps that is desired, perhaps it isn't.
> 
> Make the join slightly smarter while we're here.
