### PR TITLE
Fix some English grammar in the FAQ and Options documentation pages, along with the mouse cursor warping option

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ libraries from steam-runtime using:
 
 #### Why does my game run horribly slow?
 
-Unfortunately, for savestates to work, games must be run entire on the CPU, without the GPU. It makes games run even more slowly as they contain heavy rendering. If you don't bother about savestates, you can uncheck `Video > Force software rendering`. If you do, several options are to lower the game resolution or disable rendering effects ingame. Also, fast-forward skips rendering.
+Unfortunately, for savestates to work, games must be run entirely on the CPU, without the GPU. It makes games run even more slowly as they contain heavy rendering. If you don't bother about savestates, you can uncheck `Video > Force software rendering`. If you do, several options are to lower the game resolution or disable rendering effects ingame. Also, fast-forward skips rendering.
 
 #### When starting a game, it says "Could not determine arch of file <path>"
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,7 +15,7 @@ Short answer: no, unless it has a Linux release. Long answer: there's experiment
 
 #### Can I TAS Steam games?
 
-If Steam offers a Linux version, possibly yes. Some games from Steam are actually drm-free, so there are no issues with them. Other games will need you to enable `Virtual Steam client` setting to work. Games heavily relying on Steam features (such as multiplayer games) won't work.
+If Steam offers a Linux version, possibly yes. Some games from Steam are actually DRM-free, so there are no issues with them. Other games will need you to enable `Virtual Steam client` setting to work. Games heavily relying on Steam features (such as multiplayer games) won't work.
 
 #### My Steam game complains about some missing library
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ libraries from steam-runtime using:
 
     ~/.steam/bin/steam-runtime/run.sh libTAS
 
-#### Why does my game is horribly slow?
+#### Why does my game run horribly slow?
 
 Unfortunately, for savestates to work, games must be run entire on the CPU, without the GPU. It makes games run even more slowly as they contain heavy rendering. If you don't bother about savestates, you can uncheck `Video > Force software rendering`. If you do, several options are to lower the game resolution or disable rendering effects ingame. Also, fast-forward skips rendering.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ Unfortunately, for savestates to work, games must be run entirely on the CPU, wi
 #### When starting a game, it says "Could not determine arch of file <path>"
 
 Check that you specified the binary file for the game. Linux games often provide a script
-to launch the game (e.g. `AxiomVerge`), but the actual binary is another file 
+to launch the game (e.g. `AxiomVerge`), but the actual binary is another file
 (e.g. `AxiomVerge.bin.x86_64`).
 
 #### I'm getting an error about `System.TypeInitializationException`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,4 +38,4 @@ to launch the game (e.g. `AxiomVerge`), but the actual binary is another file
 #### I'm getting an error about `System.TypeInitializationException`
 
 This is a known [Mono bug](https://github.com/mono/mono/issues/6752), it can be
-fixed by launching libTAS like that: `term=XTERM libTAS`.
+fixed by launching libTAS like this: `term=XTERM libTAS`.

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -112,7 +112,7 @@ This option aims to prevent the game from saving its savefiles on disk. This is 
 
 One current limitation of the savestates implementation is that loading a savestate won't recreated threads that have exited since the savestate was done. It makes loading impossible in common cases like between levels, and the user will be forced to restart the entire movie because they cannot load any savestate. We can work around this limitation by recycling threads. When a game thread exits, it turns into a wait mode instead, and the next time the game creates a new thread, no thread is actually created and the thread function is passed to this waiting thread. Thanks to this, savestates are much more likely to be possible.
 
-However, some games will crash when this option is checked (e.g. recent mono games) because thread-local storage is not completely supported.
+However, some games will crash when this option is checked (e.g. recent Mono games) because thread-local storage is not completely supported.
 
 ### Virtual Steam client
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -8,9 +8,9 @@ permalink: /guides/options/
 
 ### Frames per second
 
-You have to set a fps value prior to running a game, which appears as two fields being the numerator and denominator of a fraction (e.g. `60` and `1` for 60 fps). Many games accept any value and rely on the vsync parameter to either have to game running at fixed fps depending on the screen framerate, or uncapped fps. In this case, you can set the value you want, and libtas will simulate an activated vsync with the corresponding framerate.
+You have to set an FPS value prior to running a game, which appears as two fields being the numerator and denominator of a fraction (e.g. `60` and `1` for 60 FPS). Many games accept any value and rely on the vsync parameter to either have to game running at fixed FPS depending on the screen framerate, or uncapped FPS. In this case, you can set the value you want, and libtas will simulate an activated vsync with the corresponding framerate.
 
-Some games are build with a constant framerate in mind, and setting another fps value will trigger abnormal results (like duplicate frames). In this case, it is possible to guess the intended game framerate by checking Runtime > Debug > Uncontrolled time. This will deactivate the deterministic timer, meaning that the game will access the real system time. Then, you can run the game and look at the obtained fps value. This mode is not meant to be used for TASing, because it makes inputs recording non-deterministic.
+Some games are build with a constant framerate in mind, and setting another FPS value will trigger abnormal results (like duplicate frames). In this case, it is possible to guess the intended game framerate by checking Runtime > Debug > Uncontrolled time. This will deactivate the deterministic timer, meaning that the game will access the real system time. Then, you can run the game and look at the obtained FPS value. This mode is not meant to be used for TASing, because it makes inputs recording non-deterministic.
 
 ### System Time
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -55,7 +55,7 @@ This option simulates a monitor that only supports the specified resolution, so 
 
 This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphics pipeline is done by the CPU and can be stored in the savestate.
 
-You must be using Mesa 3D to be able to use this option, which usually means that you must be using the free driver for you GPU (e.g. nouveau for nvidia GPUs or radeon for ATI/AMD CPUs)
+You must be using Mesa 3D to be able to use this option, which usually means that you must be using the free driver for your GPU (e.g. nouveau for nvidia GPUs or radeon for ATI/AMD CPUs)
 
 ### Toggle performance tweaks
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -53,7 +53,7 @@ This option simulates a monitor that only supports the specified resolution, so 
 
 ### Force software rendering
 
-This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphic pipeline is done by the CPU and can be stored in the savestate.
+This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphics pipeline is done by the CPU and can be stored in the savestate.
 
 You must be using Mesa 3D to be able to use this option, which usually means that you must be using the free driver for you GPU (e.g. nouveau for nvidia GPUs or radeon for ATI/AMD CPUs)
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -132,7 +132,7 @@ This option makes the game access the real event system. It is useful to debug g
 
 ### Configure Encode
 
-Video encode is configured in this window. The program offers some audio and video codecs as dropdown menu, which fills the corresponding FFmpeg options, but you can manually modify the options to be send to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
+Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be send to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
 
 ### Ram Search
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -132,7 +132,7 @@ This option makes the game access the real event system. It is useful to debug g
 
 ### Configure Encode
 
-Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be send to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
+Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be sent to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
 
 ### Ram Search
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -88,7 +88,7 @@ This option is good for users that don't have an SSD, but no check is performed 
 
 #### Backtrack savestate
 
-This option makes the game save a state each time savestates are invalidated by a thread creation or destruction. This state can be loaded with F10 (by default). It allows used to get back to the earliest frame that is available.
+This option makes the game save a state each time savestates are invalidated by thread creation or destruction. This state can be loaded with F10 (by default). It allows used to get back to the earliest frame that is available.
 
 #### Compressed savestates
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -63,7 +63,7 @@ When software rendering is on, you can check this to skip some steps in the rend
 
 ### On-screen Display (OSD)
 
-Displays some information on the game screen such as framecount, inputs, notifications and ram watches. The placement of those texts can be modified, and can be displayed in the encode video.
+Displays some information on the game screen such as framecount, inputs, notifications and ram watches. The placement of these texts can be modified, and can be displayed in the encode video.
 
 ### Variable framerate
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -53,7 +53,7 @@ This option simulates a monitor that only supports the specified resolution, so 
 
 ### Force software rendering
 
-This option force the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphic pipeline is done by the cpu and can be stored in the savestate.
+This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphic pipeline is done by the cpu and can be stored in the savestate.
 
 You must be using Mesa 3D to be able to use this option, which usually means that you must be using the free driver for you GPU (e.g. nouveau for nvidia GPUs or radeon for ATI/AMD CPUs)
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -110,7 +110,7 @@ This option aims to prevent the game from saving its savefiles on disk. This is 
 
 ### Recycle threads
 
-One current limitation of the savestates implementation is that loading a savestate won't recreated threads that have exited since the savestate was done. It makes loading impossible in common cases like between levels, and the user will be forced to restart the entire movie because he cannot load any savestate. We can work around this limitation by recycling threads. When a game thread exits, it turns into a wait mode instead, and the next time the game creates a new thread, no thread is actually created and the thread function is passed to this waiting thread. Thanks to this, savestates are much more likely to be possible.
+One current limitation of the savestates implementation is that loading a savestate won't recreated threads that have exited since the savestate was done. It makes loading impossible in common cases like between levels, and the user will be forced to restart the entire movie because they cannot load any savestate. We can work around this limitation by recycling threads. When a game thread exits, it turns into a wait mode instead, and the next time the game creates a new thread, no thread is actually created and the thread function is passed to this waiting thread. Thanks to this, savestates are much more likely to be possible.
 
 However, some games will crash when this option is checked (e.g. recent mono games) because thread-local storage is not completely supported.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -67,7 +67,7 @@ Displays some information on the game screen such as framecount, inputs, notific
 
 ### Variable framerate
 
-Allows the user to change the framerate during the execution of the game. It must be checked
+Allows the user to change the framerate during the execution of the game. This must be checked
 before starting the game.
 
 ## Runtime

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -53,7 +53,7 @@ This option simulates a monitor that only supports the specified resolution, so 
 
 ### Force software rendering
 
-This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphic pipeline is done by the cpu and can be stored in the savestate.
+This option forces the OpenGL device driver Mesa 3D to use its software implementation of OpenGL (llvmpipe) to run the game. While this makes the game much slower, it is usually required to be able to use savestates. Indeed, the state of the GPU cannot be easily accessed and stored into savestates by the tool, thus savestates are incomplete and may crash the game. When using Mesa's software implementation, all of the graphic pipeline is done by the CPU and can be stored in the savestate.
 
 You must be using Mesa 3D to be able to use this option, which usually means that you must be using the free driver for you GPU (e.g. nouveau for nvidia GPUs or radeon for ATI/AMD CPUs)
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -20,7 +20,7 @@ The System Time is the time that is accessed by the game. It can be set before s
 
 ### Executable Options
 
-When the game is required to be ran from a specific working directory, the `Run path` field must be set to that directory. Also, if the game is bundled with its own shared libraries, you probably want to add that library directory path to `Library path` field. Both fields can be guessed if the game is intended to be launched with a script file. You can look at the content
+When the game is required to be ran from a specific working directory, the `Run path` field must be set to that directory. Also, if the game is bundled with its own shared libraries, you probably want to add that library directory path to `Library path` field. Both fields can be guessed if the game is intended to be launched with a script file. You can look at the contents
 of the script.
 
 ## Movie

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -110,7 +110,7 @@ This option aims to prevent the game from saving its savefiles on disk. This is 
 
 ### Recycle threads
 
-One current limitation of the savestates is that loading a savestate won't recreated threads that have exited since the savestate was done. It makes loading impossible in common cases like between levels, and the user will be forced to restart the entire movie because he cannot load any savestate. We can work around this limitation by recycling threads. When a game thread exits, it turns into a wait mode instead, and the next time the game creates a new thread, no thread is actually created and the thread function is passed to this waiting thread. Thanks to this, savestates are much more likely to be possible.
+One current limitation of the savestates implementation is that loading a savestate won't recreated threads that have exited since the savestate was done. It makes loading impossible in common cases like between levels, and the user will be forced to restart the entire movie because he cannot load any savestate. We can work around this limitation by recycling threads. When a game thread exits, it turns into a wait mode instead, and the next time the game creates a new thread, no thread is actually created and the thread function is passed to this waiting thread. Thanks to this, savestates are much more likely to be possible.
 
 However, some games will crash when this option is checked (e.g. recent mono games) because thread-local storage is not completely supported.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -106,7 +106,7 @@ memory, so you can resume the game immediately.
 
 ### Prevent writing to disk
 
-This option aims to prevent the game from saving its savefiles on disk. This is useful to keep the same state of the game whenever you load a savestate or you quit and restart the game. To enable that, libTAS detects if the game opens a regular file in write mode, and instead opens a virtual file in memory with a copy of the content of the actual file. The game does not notice it and uses regular file commands (e.g. read, write, seek) on it. Because this virtual file is in memory, it is saved inside savestates and is recovered when loading a savestate. Also, when the game is closed, all the modifications in the virtual file are lost. This option may cause some games to crash, if they are doing uncommon operations with savefiles, or if the tool incorrectly detected savefiles.
+This option aims to prevent the game from saving its savefiles on disk. This is useful to keep the same state of the game whenever you load a savestate or you quit and restart the game. To enable that, libTAS detects if the game opens a regular file in write mode, and instead opens a virtual file in memory with a copy of the content of the actual file. The game does not notice it and uses regular file commands (e.g. read, write, seek) on it. Because this virtual file is in memory, it is saved inside savestates and is recovered when loading a savestate. Also, when the game is closed, all modifications to the virtual file are lost. This option may cause some games to crash, if they are doing uncommon operations with savefiles, or if the tool incorrectly detected savefiles.
 
 ### Recycle threads
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -88,7 +88,7 @@ This option is good for users that don't have an SSD, but no check is performed 
 
 #### Backtrack savestate
 
-This option makes the game save a state each time savestates are invalidated by thread creation or destruction. This state can be loaded with F10 (by default). It allows used to get back to the earliest frame that is available.
+This option makes the game save a state each time savestates are invalidated by thread creation or destruction. This state can be loaded with F10 (by default). It allows users to get back to the earliest frame that is available.
 
 #### Compressed savestates
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -156,7 +156,7 @@ The pointer scan feature will scan for pointer chains to a specific address. Sel
 ### Mouse relative mode
 
 Set the mouse position relative to the center of the screen. For exemple, if you move the cursor
-3 pixels to the right of the center of the screen, it will send to the game as if you moved
+3 pixels to the right of the center of the screen, it will be sent to the game as if you moved
 your cursor 3 pixels to the right from the last frame. This is useful for first-person
 controls, together with the next feature.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -14,7 +14,7 @@ Some games are build with a constant framerate in mind, and setting another FPS 
 
 ### System Time
 
-The System Time is the time that is accessed by the game. It can be set before starting the game to have different starting times. Because system time is often use as a seed to a random number generator, setting this value can affect the random behaviors in the game. This is why initial system time is stored in movie files. When the game has started, this value shows the current time that the game has access to.
+The System Time is the time that is accessed by the game. It can be set before starting the game to have different starting times. Because system time is often used as a seed to a random number generator, setting this value can affect the random behaviors in the game. This is why initial system time is stored in movie files. When the game has started, this value shows the current time that the game has access to.
 
 ## File
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -156,7 +156,7 @@ The pointer scan feature will scan for pointer chains to a specific address. Sel
 ### Mouse relative mode
 
 Set the mouse position relative to the center of the screen. For exemple, if you move the cursor
-3 pixels right of the center of the screen, it will send to the game as if you moved
+3 pixels to the right of the center of the screen, it will send to the game as if you moved
 your cursor 3 pixels to the right from the last frame. This is useful for first-person
 controls, together with the next feature.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -67,7 +67,7 @@ Displays some information on the game screen such as framecount, inputs, notific
 
 ### Variable framerate
 
-Allow the user to change the framerate during the game execution. It must be checked
+Allows the user to change the framerate during the game execution. It must be checked
 before starting the game.
 
 ## Runtime

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -147,7 +147,7 @@ Then, for more filtering, set the appropriate parameters and press Search. If yo
 
 ### Ram Watch
 
-A simple window to look at the ram watches. It is also possible to scan for pointers to a specific address. Because most memory is allocated dynamically, the location of a particular value that you are looking for will probably change for every game execution. To be able to keep track of this value, you can search for a chain of pointers that starts from a static address (which never change) to the actual value location. It will look like pointer -> offset -> pointer -> offset -> pointer -> offset -> location.
+A simple window to look at the ram watches. It is also possible to scan for pointers to a specific address. Because most memory is allocated dynamically, the location of a particular value that you are looking for will probably change for every game execution. To be able to keep track of this value, you can search for a chain of pointers that starts from a static address (which never changes) to the actual value location. It will look like pointer -> offset -> pointer -> offset -> pointer -> offset -> location.
 
 The pointer scan feature will scan for pointer chains to a specific address. Selecting a ram watch and pressing the button will open a new window. You can then set the maximum number of pointers in the chain and the maximum value of offsets. The Search will take some time, but all the layout is stored so you can search again with different parameters or other addresses in a very short time, as long as you don't frame advance. Then, you can store results in the Ram Watch.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -97,7 +97,7 @@ Compressed savestates save time especially for slow hard-drive disks. This optio
 #### Skip unmapped pages
 
 Save savestate space by not saving unmapped memory pages, but some games crash
-because of this. If unsure, leave unchecked
+because of this. If unsure, leave unchecked.
 
 #### Fork to save states
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -139,9 +139,9 @@ Video encode is configured in this window. The program offers some audio and vid
 There is a rudimentary Ram Search feature implemented. To start a new search, you need to:
 
 - Check the memory regions you want to include. In the most common case, you will want to only include Heap and Anon RW Mapping which are the two regions of dynamically allocated read/write memory.
-- Choose Unknown/Previous Value if you don't want to filter the results, or Specific Value if you want to filter base on a comparison to a specific value. In that case, fill the value and the operator above. Be careful that the allocated memory can be very big in some games, so whenever possible, filter the results for a new search. Also, try to filter the value 0 because a non-negligible part of memory contains zeros. If too many results are retained, the program will crash
-- Choose the type of variable to search for, and how it will be displayed
-- Press New 
+- Choose Unknown/Previous Value if you don't want to filter the results, or Specific Value if you want to filter base on a comparison to a specific value. In that case, fill the value and the operator above. Be careful that the allocated memory can be very big in some games, so whenever possible, filter the results for a new search. Also, try to filter the value 0 because a non-negligible part of memory contains zeros. If too many results are retained, the program will crash.
+- Choose the type of variable to search for, and how it will be displayed.
+- Press New.
 
 Then, for more filtering, set the appropriate parameters and press Search. If you find a result that you want to keep, you can select the row and press Add Watch. You will be able to save the address and apply a label. Then, the saved addresses are available in the Ram Watch menu.
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -132,7 +132,7 @@ This option makes the game access the real event system. It is useful to debug g
 
 ### Configure Encode
 
-Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be sent to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
+Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be sent to FFmpeg. Also, the container is determined from the file extension (e.g. naming your video encode.mkv will use the Matroska container).
 
 ### Ram Search
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -132,7 +132,7 @@ This option makes the game access the real event system. It is useful to debug g
 
 ### Configure Encode
 
-Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be sent to FFmpeg. Also, the container is determined from the file extension (e.g. naming your video encode.mkv will use the Matroska container).
+Video encode is configured in this window. The program offers some audio and video codecs as dropdown menus, which fill the corresponding FFmpeg options, but you can manually modify the options to be sent to FFmpeg. Also, the container is determined from the file extension (e.g. naming your video `encode.mkv` will use the Matroska container).
 
 ### Ram Search
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -74,7 +74,7 @@ before starting the game.
 
 ### Time tracking
 
-Some game expects, at some point, the time to advance, and wait in a loop, querying the time constantly until the time has advanced enough. However, we only advance time during a frame boundary, triggered by a screen display call. To avoid this softlock, we can let the time advance after a threshold number of calls from the same time-querying function. This option affects sync, but the game should run deterministically.
+Some games expect, at some point, the time to advance, and wait in a loop, querying the time constantly until the time has advanced enough. However, we only advance time during a frame boundary, triggered by a screen display call. To avoid this softlock, we can let the time advance after a threshold number of calls from the same time-querying function. This option affects sync, but the game should run deterministically.
 
 ### Savestates
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -20,7 +20,7 @@ The System Time is the time that is accessed by the game. It can be set before s
 
 ### Executable Options
 
-When the game requires to be run from a specific working directory, the `Run path` field must be set to that directory. Also, if the game is bundled with its own shared libraries, you probably want to add that library directory path to `Library path` field. Both fields can be guessed if the game is intended to be launched with a script file. You can look at the content
+When the game is required to be ran from a specific working directory, the `Run path` field must be set to that directory. Also, if the game is bundled with its own shared libraries, you probably want to add that library directory path to `Library path` field. Both fields can be guessed if the game is intended to be launched with a script file. You can look at the content
 of the script.
 
 ## Movie

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -165,9 +165,9 @@ controls, together with the next feature.
 This feature mimics what is used by first-person games so that the pointer does
 not go past the game screen.
 
-### Prevents games to warp pointer
+### Prevent games from warping the mouse cursor
 
-If checked, libTAS will prevent games to warp the pointer (but will still register
+If checked, libTAS will prevent games from warping the mouse cursor (but will still register
 the warp internally).
 
 ### Recalibrate mouse position

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -126,7 +126,7 @@ This option makes the game access the real system time. It is useful to see if a
 
 #### Native events
 
-This option makes the game access the real event system. It is useful to debug games that don't take inputs from the user. Checking this option may make input recording not working.
+This option makes the game access the real event system. It is useful to debug games that don't take inputs from the user. Checking this option may make input recording not work.
 
 ## Tools
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -59,7 +59,7 @@ You must be using Mesa 3D to be able to use this option, which usually means tha
 
 ### Toggle performance tweaks
 
-When software rendering is on, you can check this to skip some steps in the rendering pipeline, which can gives a small performance boost.
+When software rendering is on, you can check this to skip some steps in the rendering pipeline, which can give a small performance boost.
 
 ### On-screen Display (OSD)
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -92,7 +92,7 @@ This option makes the game save a state each time savestates are invalidated by 
 
 #### Compressed savestates
 
-Compressed savestates save time especially for slow hard-drive disks. It is recommended.
+Compressed savestates save time especially for slow hard-drive disks. This option is recommended.
 
 #### Skip unmapped pages
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -132,7 +132,7 @@ This option makes the game access the real event system. It is useful to debug g
 
 ### Configure Encode
 
-Video encode is configured in this window. The program offers some audio and video codecs as dropdown menu, which fills the corresponding ffmpeg options, but you can manually modify the options to be send to ffmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
+Video encode is configured in this window. The program offers some audio and video codecs as dropdown menu, which fills the corresponding FFmpeg options, but you can manually modify the options to be send to FFmpeg. Also, the container is determined from the file extension (e.g. name your video encode.mkv will use the Matroska container).
 
 ### Ram Search
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -116,7 +116,7 @@ However, some games will crash when this option is checked (e.g. recent Mono gam
 
 ### Virtual Steam client
 
-When enabled, it will simulate a dummy Steam client in case games want to connect to Steam. This is mandatory for games that require Steam to be opened, because libTAS does not work with Steam. The implementation of this dummy client is not completed, so it won't work with all games.
+When enabled, it will simulate a dummy Steam client in case games want to connect to Steam. This is mandatory for games that require Steam to be opened, because libTAS does not work with Steam. The implementation of this dummy client is not complete, so it won't work with all games.
 
 ### Debug
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -80,7 +80,7 @@ Some games expect, at some point, the time to advance, and wait in a loop, query
 
 #### Incremental savestates
 
-The Incremental savestates option allows taking advantage of the recent soft-dirty bit pushed by CRIU project, which can track which memory pages have been written to. When the first savestate is triggered, a complete memory dump is performed (like a regular savestate), but the soft-dirty bit is cleared. If another savestate is performed, only the memory pages that were modified since are saved, leading to lightweight savestates. However, to be effective, this option requires the user to make the first savestate as late as possible. The tool detects at startup if this feature is available on the system, and disables the option if not.
+The Incremental savestates option allows taking advantage of the recent soft-dirty bit pushed by the CRIU project, which can track which memory pages have been written to. When the first savestate is triggered, a complete memory dump is performed (like a regular savestate), but the soft-dirty bit is cleared. If another savestate is performed, only the memory pages that were modified since are saved, leading to lightweight savestates. However, to be effective, this option requires the user to make the first savestate as late as possible. The tool detects at startup if this feature is available on the system, and disables the option if not.
 
 #### Store savestates in RAM
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -106,7 +106,7 @@ memory, so you can resume the game immediately.
 
 ### Prevent writing to disk
 
-This option aims at preventing the game to save in savefiles on disk. This is useful to keep the same state of the game whenever you load a savestate or you quit and restart the game. To enable that, libTAS detects if the game opens a regular file in write mode, and instead opens a virtual file in memory with a copy of the content of the actual file. The game does not notice it and uses regular file commands (e.g. read, write, seek) on it. Because this virtual file is in memory, it is saved inside savestates and is recovered when loading a savestate. Also, when the game is closed, all the modifications in the virtual file are lost. This option may cause some games to crash, if they are doing uncommon operations with savefiles, or if the tool incorrectly detected savefiles.
+This option aims to prevent the game from saving its savefiles on disk. This is useful to keep the same state of the game whenever you load a savestate or you quit and restart the game. To enable that, libTAS detects if the game opens a regular file in write mode, and instead opens a virtual file in memory with a copy of the content of the actual file. The game does not notice it and uses regular file commands (e.g. read, write, seek) on it. Because this virtual file is in memory, it is saved inside savestates and is recovered when loading a savestate. Also, when the game is closed, all the modifications in the virtual file are lost. This option may cause some games to crash, if they are doing uncommon operations with savefiles, or if the tool incorrectly detected savefiles.
 
 ### Recycle threads
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -102,7 +102,7 @@ because of this. If unsure, leave unchecked.
 #### Fork to save states
 
 Use the `fork()` feature to create a copy of the game process that will save its
-memory, so you can resume the game immediatly.
+memory, so you can resume the game immediately.
 
 ### Prevent writing to disk
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -67,7 +67,7 @@ Displays some information on the game screen such as framecount, inputs, notific
 
 ### Variable framerate
 
-Allows the user to change the framerate during the game execution. It must be checked
+Allows the user to change the framerate during the execution of the game. It must be checked
 before starting the game.
 
 ## Runtime

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -80,7 +80,7 @@ Some games expect, at some point, the time to advance, and wait in a loop, query
 
 #### Incremental savestates
 
-The Incremental savestates option allows to take advantage of the recent soft-dirty bit pushed by CRIU project, which can track which memory pages have been written to. When the first savestate is triggered, a complete memory dump is performed (like a regular savestate), but the soft-dirty bit is cleared. If another savestate is performed, only the memory pages that were modified since are saved, leading to lightweight savestates. However, to be effective, this option requires the user to make the first savestate as late as possible. The tool detects at startup if this feature is available on the system, and disables the option if not.
+The Incremental savestates option allows taking advantage of the recent soft-dirty bit pushed by CRIU project, which can track which memory pages have been written to. When the first savestate is triggered, a complete memory dump is performed (like a regular savestate), but the soft-dirty bit is cleared. If another savestate is performed, only the memory pages that were modified since are saved, leading to lightweight savestates. However, to be effective, this option requires the user to make the first savestate as late as possible. The tool detects at startup if this feature is available on the system, and disables the option if not.
 
 #### Store savestates in RAM
 

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -823,7 +823,7 @@ void MainWindow::createMenus()
     mouseModeAction->setCheckable(true);
     mouseWarpAction = inputMenu->addAction(tr("Warp mouse to center each frame"), this, &MainWindow::slotMouseWarp);
     mouseWarpAction->setCheckable(true);
-    mouseGameWarpAction = inputMenu->addAction(tr("Prevent games to warp the mouse cursor"), this, &MainWindow::slotMouseGameWarp);
+    mouseGameWarpAction = inputMenu->addAction(tr("Prevent games from warping the mouse cursor"), this, &MainWindow::slotMouseGameWarp);
     mouseGameWarpAction->setCheckable(true);
 
     QMenu *joystickMenu = inputMenu->addMenu(tr("Joystick support"));


### PR DESCRIPTION
This PR fixes some English grammar, starting with the name of the mouse cursor warping option, then fixing some English in the FAQ page, but it mostly fixes English everywhere in the Options page that was added in c78012b5959df5841d26346c778918c39999328b.