### PR TITLE
Don't omit middle operand of ternary expression

### DIFF
--- a/src/library/BusyLoopDetection.cpp
+++ b/src/library/BusyLoopDetection.cpp
@@ -160,7 +160,7 @@ void BusyLoopDetection::increment(int type)
                     info.dli_saddr = info.dli_fbase;
 
                 if (info.dli_sname != NULL || info.dli_saddr != 0) {
-                    oss << "(" << (info.dli_sname ?: "");
+                    oss << "(" << (info.dli_sname ? info.dli_sname : "");
                     if (info.dli_saddr != 0) {
                         if (addresses[cnt] >= (void *)info.dli_saddr) {
                             oss << '+' << std::hex << (reinterpret_cast<intptr_t>(addresses[cnt]) - reinterpret_cast<intptr_t>(info.dli_saddr));


### PR DESCRIPTION
Omitting the middle operand of a ternary expression is a GCC compiler extension and is non-standard. This means the code can't otherwise be compiled on Clang, for example.

The extension is equivalent to repeating the first operand (without its implicit conversion to bool), except it doesn't double-evaluate. However, in this case, the first expression is of a pointer, so it's perfectly okay to double-evaluate it here.