### PR TITLE
Fix bounds check in SaveStateList::get()

### DIFF
--- a/src/program/SaveStateList.cpp
+++ b/src/program/SaveStateList.cpp
@@ -46,7 +46,7 @@ void SaveStateList::init(Context* context)
 
 SaveState& SaveStateList::get(int id)
 {
-    if (id < 0 || id > NB_STATES) {
+    if (id < 0 || id >= NB_STATES) {
         std::cerr << "Unknown savestate " << id << std::endl;
         id = 0;
     }


### PR DESCRIPTION
The "greater than" was missing an "or equal to".

`NB_STATES` here is `#define`d to be 11. So that means the list of valid IDs goes like 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 - but doesn't include 11 itself. 11 is not an ID, it is only an amount. And there are only 11 numbers between 0 and 10 inclusive. That means 11 will need to be rejected alongside all the other invalid IDs, which means including it in the conditional, since this is a negative conditional.

Alternatively, one could consider the positive version of this conditional, which would look something like `id >= 0 && id < NB_STATES`. The `id < NB_STATES` is used frequently in constructs like for-loops (which you can view in the same file), and you can assure yourself that the `id >= 0` is correct, because arrays start from 0, and it should obviously include the 0.

Then, to negate the conditional and get the negative version, you must negate all statements, plus its conjunctions (this is called De Morgan's laws). So you would negate the two lesser-/greater-than comparisons, plus change the "and" into an "or". And to negate lesser-/greater-than comparisons, you flip the sign around and toggle the "or equal to". So we would change the "greater than or equal to" to "less than", and the "less than" to "greater than or equal to".