### PR TITLE
Use VK_NULL_HANDLE instead of nullptr when destroying vkScreenImage

### DIFF
--- a/src/library/ScreenCapture.cpp
+++ b/src/library/ScreenCapture.cpp
@@ -450,12 +450,12 @@ void ScreenCapture::destroyScreenSurface()
     if (vkScreenImageMemory) {
         LINK_NAMESPACE(vkFreeMemory, "vulkan");
         orig::vkFreeMemory(vk::device, vkScreenImageMemory, nullptr);
-        vkScreenImageMemory = nullptr;
+        vkScreenImageMemory = VK_NULL_HANDLE;
     }
     if (vkScreenImage) {
         LINK_NAMESPACE(vkDestroyImage, "vulkan");
         orig::vkDestroyImage(vk::device, vkScreenImage, nullptr);
-        vkScreenImage = nullptr;
+        vkScreenImage = VK_NULL_HANDLE;
     }
 }
 


### PR DESCRIPTION
This fixes a compile error, because `vkScreenImage` and `vkScreenImageMemory` here are both ints, and not pointers, so `nullptr` can't be used here. However, `VK_NULL_HANDLE` is an int (and it seems like you're intended to use it here), so replacing it here will fix the compile error.