### PR TITLE
Fix #399 by respecting runpaths in dlopen.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,16 +1,20 @@
 all: hooklib3 hooklib2 hooklib1 hookmain
 
 hookmain: hookmain.c
-	gcc -g -o hookmain hookmain.c -lhooklib1 -ldl -L.
+	gcc -g -o hookmain hookmain.c -lhooklib1 -ldl -Lhooklib1 -Wl,-rpath,hooklib1:hooklib2
 
 hooklib1: hooklib1.c
-	gcc -g -o libhooklib1.so hooklib1.c -shared
+	mkdir -p hooklib1
+	gcc -g -o hooklib1/libhooklib1.so hooklib1.c -shared
 
 hooklib2: hooklib2.c hooklib3.c
-	gcc -g -o libhooklib2.so hooklib2.c -lhooklib3 -shared -L.
+	mkdir -p hooklib2
+	gcc -g -o hooklib2/libhooklib2.so hooklib2.c -lhooklib3 -shared -Lhooklib3 -Wl,-rpath,hooklib3
 
 hooklib3: hooklib3.c
-	gcc -g -o libhooklib3.so hooklib3.c -shared
+	mkdir -p hooklib3
+	gcc -g -o hooklib3/libhooklib3.so hooklib3.c -shared
 
 clean:
-	rm hookmain libhooklib1.so libhooklib2.so libhooklib3.so
+	rm -f hookmain hooklib1/libhooklib1.so hooklib2/libhooklib2.so hooklib3/libhooklib3.so
+	rmdir hooklib1 hooklib2 hooklib3 2>/dev/null

--- a/test/hookmain.c
+++ b/test/hookmain.c
@@ -17,10 +17,14 @@ int main()
         printf("Hooking failed!\n");
     }
 
-    printf("Hooking a dynamic function\n");
-    void* handle = dlopen("./libhooklib2.so", RTLD_LAZY);
-    int (*func)() = (int (*)()) dlsym(handle, "libtasTestFunc2");
+    printf("Loading a dynamic library\n");
+    void* handle = dlopen("libhooklib2.so", RTLD_LAZY);
+    if (!handle) {
+        printf("Cound not load library libhooklib2.so from runpath!\n");
+    }
 
+    printf("Hooking a dynamic function\n");
+    int (*func)() = (int (*)()) dlsym(handle, "libtasTestFunc2");
     if (!func) {
         printf("Cound not link to function libtasTestFunc2!\n");
     }


### PR DESCRIPTION
My first idea didn't work, so the best solution I could come up with is to get the list of search paths for the calling object and try to open each one manually.  Also modified test hook objects to use runpaths for testing purposes.