### PR TITLE
Fix various crashes.

### DIFF
--- a/src/library/frame.cpp
+++ b/src/library/frame.cpp
@@ -225,7 +225,9 @@ void frameBoundary(std::function<void()> draw)
     /* If the game is exiting, dont process the frame boundary, just draw and exit */
     if (is_exiting) {
         detTimer.flushDelay();
-        NATIVECALL(draw());
+
+        if (draw)
+            NATIVECALL(draw());
 
         /* Still push native events so that the game can exit properly */
         if ((game_info.video & GameInfo::SDL1) || (game_info.video & GameInfo::SDL2)) {

--- a/src/program/utils.cpp
+++ b/src/program/utils.cpp
@@ -135,7 +135,7 @@ int extractBinaryType(std::string path)
         macappflag = BT_MACOSAPP;
     }
     
-    std::string cmd = "file -b \"";
+    std::string cmd = "file --brief --dereference \"";
     cmd += path;
     cmd += "\"";
 

--- a/src/shared/sockethelpers.cpp
+++ b/src/shared/sockethelpers.cpp
@@ -137,7 +137,7 @@ int sendData(const void* elem, unsigned int size)
 
     ssize_t ret = 0;
     do {
-        ret = send(socket_fd, elem, size, 0);
+        ret = send(socket_fd, elem, size, MSG_NOSIGNAL);
     } while ((ret == -1) && (errno == EINTR));
 
     if (ret == -1) {


### PR DESCRIPTION
- Fix call to draw causing an unhandled exception.
- Fix `file` command failing when used on symbolic links.
- Fix #374 `SIGPIPE` terminating libTAS program.