### PR TITLE
Use dlopen_from on macOS

### DIFF
--- a/libTAS.xcodeproj/project.pbxproj
+++ b/libTAS.xcodeproj/project.pbxproj
@@ -1859,6 +1859,12 @@
 					"$(OTHER_CFLAGS)",
 					"-fno-stack-protector",
 				);
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-U",
+					"-Xlinker",
+					_dlopen_from,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1890,6 +1896,12 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-fno-stack-protector",
+				);
+				OTHER_LDFLAGS = (
+					"-Xlinker",
+					"-U",
+					"-Xlinker",
+					_dlopen_from,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
From the macOS support issue (#403):

> * [ ] Executables can store its list of linked library paths using relative paths, but because we hook dlopen(), the caller is not the executable anymore but our library. Special paths like @loader_path (directory of the caller path) and @rpath (special path included in the caller header section) won't work anymore

This should hopefully fix this. I have been able to compile libTAS with this patch, but I haven't been able to launch anything with libTAS (due to an unrelated issue). Linux compilation still works.

This patch uses the `dlopen_from` function, which is defined in [this `.c` file](https://opensource.apple.com/source/dyld/dyld-832.7.3/src/dyldAPIsInLibSystem.cpp.auto.html) and [this header file](https://opensource.apple.com/source/dyld/dyld-832.7.3/src/dyldAPIsInLibSystem.cpp.auto.html). In this patch I just declare the function inside the `dlhook.cpp` file, which might not be ideal, but I don't know where else to put it. I can't just use Apples official header file because it doesn't set `__attribute__((weak))`.

The `dlopen_from` function appears to have been introduced in macOS Big Sur (according to the Apple header file: "Available in macOS 11.0 and iOS 14.0 and later"). Therefore I use `__attribute__((weak))` on `dlopen_from` and only call it if it is defined. Note that the program must be compiled with `-Wl,-U,_dlopen_from` on macOS versions older than Big Sur.

Ideally, if I can convince glibc to implement `dlopen_from` in glibc too we could just remove the `#if defined(__APPLE__) && defined(__MACH__)` conditions.