### PR TITLE
Fixed bug allowing the creation of empty columns in the input editor

### DIFF
--- a/src/program/ui/InputEditorView.cpp
+++ b/src/program/ui/InputEditorView.cpp
@@ -450,24 +450,26 @@ void InputEditorView::addInputColumn()
     /* Remove the custom modifiers that we added in that function */
     ks = ks & 0xffff;
 
-    /* Get the input with description if available */
-    for (int i=0; i<KeyMapping::INPUTLIST_SIZE; i++) {
-        for (auto iter : context->config.km->input_list[i]) {
-            if (iter.type == SingleInput::IT_KEYBOARD) {
-                if (iter.value == ks) {
-                    inputEditorModel->addUniqueInput(iter);
-                    return;
+    if (ks != 0) {
+        /* Get the input with description if available */
+        for (int i=0; i<KeyMapping::INPUTLIST_SIZE; i++) {
+            for (auto iter : context->config.km->input_list[i]) {
+                if (iter.type == SingleInput::IT_KEYBOARD) {
+                    if (iter.value == ks) {
+                        inputEditorModel->addUniqueInput(iter);
+                        return;
+                    }
                 }
             }
         }
-    }
 
-    /* Didn't find the input in the list, insert it with the value as description */
-    SingleInput si;
-    si.type = SingleInput::IT_KEYBOARD;
-    si.value = ks;
-    si.description = std::to_string(ks);
-    inputEditorModel->addUniqueInput(si);
+        /* Didn't find the input in the list, insert it with the value as description */
+        SingleInput si;
+        si.type = SingleInput::IT_KEYBOARD;
+        si.value = ks;
+        si.description = std::to_string(ks);
+        inputEditorModel->addUniqueInput(si);
+    }
 }
 
 void InputEditorView::clearInputColumn()


### PR DESCRIPTION
This commit fixes a bug in the input editor where closing the "add a input column" dialog without pressing a key would create an input column for keycode 0.