### PR TITLE
Bug fixes for hotkey and input mappings

### DIFF
--- a/src/program/KeyMapping.h
+++ b/src/program/KeyMapping.h
@@ -124,6 +124,9 @@ class KeyMapping {
         /* Convert a native keycode into xcb keysym */
         virtual keysym_t nativeToKeysym(int keycode) {return keycode;}
 
+        /* Map keyboard KeySym with modifiers to keyboard KeySym without modifiers */
+        std::map<keysym_t,keysym_t> keysym_mapping;
+
         /* Map keyboard KeySym to a single input of a keyboard or controller */
         std::map<keysym_t,SingleInput> input_mapping;
 

--- a/src/program/KeyMapping.h
+++ b/src/program/KeyMapping.h
@@ -124,9 +124,6 @@ class KeyMapping {
         /* Convert a native keycode into xcb keysym */
         virtual keysym_t nativeToKeysym(int keycode) {return keycode;}
 
-        /* Map keyboard KeySym with modifiers to keyboard KeySym without modifiers */
-        std::map<keysym_t,keysym_t> keysym_mapping;
-
         /* Map keyboard KeySym to a single input of a keyboard or controller */
         std::map<keysym_t,SingleInput> input_mapping;
 

--- a/src/program/KeyMappingXcb.cpp
+++ b/src/program/KeyMappingXcb.cpp
@@ -70,6 +70,9 @@ KeyMappingXcb::KeyMappingXcb(void* c) : KeyMapping(c)
         }
     }
 
+    /* Build the map between keysym values with modifiers and keysym values without modifiers */
+    base_keysyms();
+
     /* Set default hotkeys */
     default_hotkeys();
 
@@ -150,6 +153,32 @@ std::string KeyMappingXcb::input_description_mod(keysym_t ks)
 
     str += input_description(ks);
     return str;
+}
+
+void KeyMappingXcb::base_keysyms()
+{
+    keysym_mapping.clear();
+
+    /* Map all keycode + modifier combinations to the keysym obtained without modifiers */
+
+    /* Gather the list of valid X11 KeyCode values */
+    xcb_keycode_t min_keycode = xcb_get_setup(conn)->min_keycode;
+    xcb_keycode_t max_keycode = xcb_get_setup(conn)->max_keycode;
+
+    /* Retrieve the current keyboard mapping */
+    xcb_get_keyboard_mapping_cookie_t keyboard_mapping_cookie = xcb_get_keyboard_mapping(conn, min_keycode, max_keycode - min_keycode + 1);
+    xcb_get_keyboard_mapping_reply_t* keyboard_mapping = xcb_get_keyboard_mapping_reply(conn, keyboard_mapping_cookie, nullptr);
+    xcb_keysym_t* keyboard_keysyms = xcb_get_keyboard_mapping_keysyms(keyboard_mapping);
+
+    for (int kc=0; kc<xcb_get_keyboard_mapping_keysyms_length(keyboard_mapping); kc+=keyboard_mapping->keysyms_per_keycode) {
+        for (int k=0; k<keyboard_mapping->keysyms_per_keycode; k++) {
+            xcb_keysym_t ks = keyboard_keysyms[kc + k];
+
+            if (ks == XCB_NO_SYMBOL) continue;
+
+            keysym_mapping[ks] = keyboard_keysyms[kc];
+        }
+    }
 }
 
 void KeyMappingXcb::default_inputs()

--- a/src/program/KeyMappingXcb.cpp
+++ b/src/program/KeyMappingXcb.cpp
@@ -179,6 +179,17 @@ void KeyMappingXcb::base_keysyms()
             keysym_mapping[ks] = keyboard_keysyms[kc];
         }
     }
+
+    free(keyboard_mapping);
+}
+
+keysym_t KeyMappingXcb::nativeToKeysym(int keycode) {
+    /* Convert native virtual key to the keysym obtained without modifiers */
+    if (keysym_mapping.find(keycode) != keysym_mapping.end()) {
+        return keysym_mapping[keycode];
+    }
+
+    return keycode;
 }
 
 void KeyMappingXcb::default_inputs()

--- a/src/program/KeyMappingXcb.cpp
+++ b/src/program/KeyMappingXcb.cpp
@@ -183,7 +183,8 @@ void KeyMappingXcb::base_keysyms()
     free(keyboard_mapping);
 }
 
-keysym_t KeyMappingXcb::nativeToKeysym(int keycode) {
+keysym_t KeyMappingXcb::nativeToKeysym(int keycode)
+{
     /* Convert native virtual key to the keysym obtained without modifiers */
     if (keysym_mapping.find(keycode) != keysym_mapping.end()) {
         return keysym_mapping[keycode];

--- a/src/program/KeyMappingXcb.h
+++ b/src/program/KeyMappingXcb.h
@@ -41,6 +41,9 @@ class KeyMappingXcb : public KeyMapping {
         /* Get the input description with modifiers */
         std::string input_description_mod(keysym_t ks);
 
+        /* Builds the keysym to keysym without modifier map */
+        void base_keysyms();
+
         /* Set hotkeys to default values */
         void default_inputs();
 

--- a/src/program/KeyMappingXcb.h
+++ b/src/program/KeyMappingXcb.h
@@ -41,6 +41,9 @@ class KeyMappingXcb : public KeyMapping {
         /* Get the input description with modifiers */
         std::string input_description_mod(keysym_t ks);
 
+        /* Convert a native keycode into xcb keysym */
+        keysym_t nativeToKeysym(int keycode);
+
         /* Builds the keysym to keysym without modifier map */
         void base_keysyms();
 
@@ -69,6 +72,9 @@ class KeyMappingXcb : public KeyMapping {
 
         /* Connection to the keyboard layout */
         xcb_key_symbols_t *keysyms;
+
+        /* Map keyboard KeySym with modifiers to keyboard KeySym without modifiers */
+        std::map<keysym_t,keysym_t> keysym_mapping;
 
         /* Returns the list of modifiers from the keyboard state */
         keysym_t build_modifiers(unsigned char keyboard_state[]);

--- a/src/program/ui/ControllerTabWindow.cpp
+++ b/src/program/ui/ControllerTabWindow.cpp
@@ -180,19 +180,20 @@ void ControllerTabWindow::slotGetInputs(const AllInputs &ai)
 void ControllerTabWindow::keyPressEvent(QKeyEvent *e)
 {
     keysym_t mod = convertQtModifiers(e->modifiers());
+    keysym_t ks = context->config.km->nativeToKeysym(e->nativeVirtualKey());
 
-    if (context->config.km->hotkey_mapping.find(e->nativeVirtualKey() | mod) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[e->nativeVirtualKey() | mod];
+    if (context->config.km->hotkey_mapping.find(ks | mod) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks | mod];
         context->hotkey_pressed_queue.push(hk.type);
         return;
     }
-    if (context->config.km->hotkey_mapping.find(e->nativeVirtualKey()) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[e->nativeVirtualKey()];
+    if (context->config.km->hotkey_mapping.find(ks) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks];
         context->hotkey_pressed_queue.push(hk.type);
         return;
     }
-    if (context->config.km->input_mapping.find(e->nativeVirtualKey()) != context->config.km->input_mapping.end()) {
-        SingleInput si = context->config.km->input_mapping[e->nativeVirtualKey()];
+    if (context->config.km->input_mapping.find(ks) != context->config.km->input_mapping.end()) {
+        SingleInput si = context->config.km->input_mapping[ks];
         if (si.inputTypeIsController())
             return slotButtonToggle(si.inputTypeToControllerNumber(), si.inputTypeToInputNumber(), true);
     }
@@ -203,19 +204,20 @@ void ControllerTabWindow::keyPressEvent(QKeyEvent *e)
 void ControllerTabWindow::keyReleaseEvent(QKeyEvent *e)
 {
     keysym_t mod = convertQtModifiers(e->modifiers());
+    keysym_t ks = context->config.km->nativeToKeysym(e->nativeVirtualKey());
 
-    if (context->config.km->hotkey_mapping.find(e->nativeVirtualKey() | mod) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[e->nativeVirtualKey() | mod];
+    if (context->config.km->hotkey_mapping.find(ks | mod) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks | mod];
         context->hotkey_released_queue.push(hk.type);
         return;
     }
-    if (context->config.km->hotkey_mapping.find(e->nativeVirtualKey()) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[e->nativeVirtualKey()];
+    if (context->config.km->hotkey_mapping.find(ks) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks];
         context->hotkey_released_queue.push(hk.type);
         return;
     }
-    if (context->config.km->input_mapping.find(e->nativeVirtualKey()) != context->config.km->input_mapping.end()) {
-        SingleInput si = context->config.km->input_mapping[e->nativeVirtualKey()];
+    if (context->config.km->input_mapping.find(ks) != context->config.km->input_mapping.end()) {
+        SingleInput si = context->config.km->input_mapping[ks];
         if (si.inputTypeIsController())
             return slotButtonToggle(si.inputTypeToControllerNumber(), si.inputTypeToInputNumber(), false);
     }

--- a/src/program/ui/InputEditorView.cpp
+++ b/src/program/ui/InputEditorView.cpp
@@ -453,6 +453,11 @@ void InputEditorView::addInputColumn()
     ks = ks & 0xffff;
 
     if (ks != 0) {
+        /* Get the remapped input if available */
+        if (context->config.km->input_mapping.find(ks) != context->config.km->input_mapping.end()) {
+            ks = context->config.km->input_mapping[ks].value;
+        }
+
         /* Get the input with description if available */
         for (int i=0; i<KeyMapping::INPUTLIST_SIZE; i++) {
             for (auto iter : context->config.km->input_list[i]) {

--- a/src/program/ui/InputEditorView.cpp
+++ b/src/program/ui/InputEditorView.cpp
@@ -380,14 +380,15 @@ void InputEditorView::keyPressEvent(QKeyEvent *event)
 
     /* We accept hotkeys when this window has focus */
     keysym_t mod = convertQtModifiers(event->modifiers());
+    keysym_t ks = context->config.km->nativeToKeysym(event->nativeVirtualKey());
 
-    if (context->config.km->hotkey_mapping.find(event->nativeVirtualKey() | mod) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[event->nativeVirtualKey() | mod];
+    if (context->config.km->hotkey_mapping.find(ks | mod) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks | mod];
         context->hotkey_pressed_queue.push(hk.type);
         return;
     }
-    if (context->config.km->hotkey_mapping.find(event->nativeVirtualKey()) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[event->nativeVirtualKey()];
+    if (context->config.km->hotkey_mapping.find(ks) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks];
         context->hotkey_pressed_queue.push(hk.type);
         return;
     }
@@ -399,14 +400,15 @@ void InputEditorView::keyReleaseEvent(QKeyEvent *event)
 {
     /* We accept hotkeys when this window has focus */
     keysym_t mod = convertQtModifiers(event->modifiers());
+    keysym_t ks = context->config.km->nativeToKeysym(event->nativeVirtualKey());
 
-    if (context->config.km->hotkey_mapping.find(event->nativeVirtualKey() | mod) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[event->nativeVirtualKey() | mod];
+    if (context->config.km->hotkey_mapping.find(ks | mod) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks | mod];
         context->hotkey_released_queue.push(hk.type);
         return;
     }
-    if (context->config.km->hotkey_mapping.find(event->nativeVirtualKey()) != context->config.km->hotkey_mapping.end()) {
-        HotKey hk = context->config.km->hotkey_mapping[event->nativeVirtualKey()];
+    if (context->config.km->hotkey_mapping.find(ks) != context->config.km->hotkey_mapping.end()) {
+        HotKey hk = context->config.km->hotkey_mapping[ks];
         context->hotkey_released_queue.push(hk.type);
         return;
     }


### PR DESCRIPTION
This pull request aims to fix a couple bugs with the hotkey and input mappings, namely:
- #301 and similar bugs, where the hotkey/input defined using the KeyPressedDialog uses the keysym given by Qt, which takes into account the modifiers held, while the keysym given by XCB does not. This causes certain hotkeys to only work in the Qt windows (InputEditorView, ControllerTabWindow) and not in the main game window.
- When adding an input column in the input editor, the current input mapping is not taken into account: eg. if key A is mapped to key B, pressing key A in the dialog will add a column corresponding to key A, not key B. I wasn't sure if this was intended behavior, but the commit can be reverted if needed.