### PR TITLE
Include stddef.h in vulkan_core.h

### DIFF
--- a/src/external/vulkan_core.h
+++ b/src/external/vulkan_core.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
 
 
 #define VK_VERSION_1_0 1


### PR DESCRIPTION
Alternatively we could just re-add `vk_platform.h` and un-remove `#include "vk_platform.h"` from `vulkan_core.h`.