### PR TITLE
Randomize socket filename

### DIFF
--- a/src/program/Context.h
+++ b/src/program/Context.h
@@ -147,6 +147,9 @@ struct Context {
     
     /* Indicate if at least one savestate was performed, for backtrack savestate */
     bool didASavestate = false;
+
+    /* Socket filename */
+    std::string socket_filename;
 };
 
 #endif

--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -184,9 +184,9 @@ void GameLoop::init()
     remove_savestates(context);
 
     /* Remove the file socket */
-    int err = removeSocket();
+    int err = removeSocket(context->socket_filename);
     if (err != 0)
-        emit alertToShow(QString("Could not remove socket file /tmp/libTAS.socket: %2").arg(strerror(err)));
+        emit alertToShow(QString("Could not remove socket file %1: %2").arg(context->socket_filename.c_str(), strerror(err)));
 
     /* Init savestate list */
     SaveStateList::init(context);
@@ -268,7 +268,7 @@ void GameLoop::init()
 void GameLoop::initProcessMessages()
 {
     /* Connect to the socket between the program and the game */
-    initSocketProgram();
+    initSocketProgram(context->socket_filename);
 
     /* Receive informations from the game */
     int message = receiveMessage();

--- a/src/program/GameThread.cpp
+++ b/src/program/GameThread.cpp
@@ -67,6 +67,11 @@ void GameThread::launch(Context *context)
      */
     setenv("PWD", newdir.c_str(), 1);
 
+    /* Set the LIBTAS_SOCKET environment variable to context->socket_filename
+     * so that the game knows what the socket is called
+     */
+    setenv("LIBTAS_SOCKET", context->socket_filename.c_str(), 1);
+
     /* Set where stderr of the game is redirected */
     int fd;
     std::string logfile = context->gamepath + ".log";

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -260,6 +260,11 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Randomize socket filename */
+    char templ[] = "/tmp/libTAS-XXXXXX";
+    context.socket_filename = mkdtemp(templ);
+    context.socket_filename += "/socket";
+
     /* Create the working directories */
     char *path = getenv("XDG_CONFIG_HOME");
     if (path) {

--- a/src/shared/sockethelpers.h
+++ b/src/shared/sockethelpers.h
@@ -24,10 +24,15 @@
 #include <string>
 
 /* Remove the socket file and return error */
-int removeSocket();
+int removeSocket(const std::string& socket_filename);
+
+/* Returns the socket filename from environment variable (in the game, for
+ * program use context->socket_filename)
+ */
+std::string getSocketFilenameGame(void);
 
 /* Initiate a socket connection with the game */
-bool initSocketProgram(void);
+bool initSocketProgram(const std::string& socket_filename);
 
 /* Initiate a socket connection with libTAS */
 bool initSocketGame(void);


### PR DESCRIPTION
~~I'll probably want to find a way to use something other than `tmpnam` to generate the name of the socket, because:~~

- ~~Using `tmpnam` causes a deprecation warning~~
- ~~There is a possibility of someone else creating a file with the same name as ours by accident~~

There is also the fact that it leaves undeleted socket files in `/tmp` (but so did it before the patch too, it's just more obvious when the files get a different name each time)