### PR TITLE
A couple improvements to debugger support

### DIFF
--- a/src/library/main.cpp
+++ b/src/library/main.cpp
@@ -160,6 +160,10 @@ void __attribute__((constructor)) init(void)
         message = receiveMessage();
     }
 
+    if (shared_config.sigint_upon_launch) {
+        raise(SIGINT);
+    }
+
     /* Set the frame count to the initial frame count */
     framecount = shared_config.initial_framecount;
 

--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -58,6 +58,8 @@ void Config::save(const std::string& gamepath) {
     }
     general_settings.endArray();
 
+    general_settings.setValue("debugger", debugger);
+
     /* Open the preferences for the game */
     QSettings settings(iniPath(gamepath), QSettings::IniFormat);
     settings.setFallbacksEnabled(false);
@@ -173,6 +175,12 @@ void Config::load(const std::string& gamepath) {
         recent_gamepaths.push_back(path);
     }
     general_settings.endArray();
+
+#ifdef __unix__
+    debugger = general_settings.value("debugger", debugger).toInt();
+#elif defined(__APPLE__) && defined(__MACH__)
+    debugger = DEBUGGER_LLDB;
+#endif
 
     if (gamepath.empty())
         return;

--- a/src/program/Config.h
+++ b/src/program/Config.h
@@ -130,6 +130,17 @@ public:
     /* Load a game-specific config from the config file */
     void load(const std::string& gamepath);
 
+    enum Debugger {
+        DEBUGGER_GDB = 0,
+        DEBUGGER_LLDB = 1,
+    };
+
+#ifdef __unix__
+    int debugger = DEBUGGER_GDB;
+#elif defined(__APPLE__) && defined(__MACH__)
+    int debugger = DEBUGGER_LLDB;
+#endif
+
 private:
     QString iniPath(const std::string& gamepath) const;
 };

--- a/src/program/ui/ErrorChecking.cpp
+++ b/src/program/ui/ErrorChecking.cpp
@@ -200,19 +200,29 @@ bool ErrorChecking::checkArchType(Context* context)
 
     /* Check for gdb presence in case of Start and attach gdb */
     if (context->attach_gdb) {
-        std::string cmd = "which gdb";
+        std::string cmd;
+
+        switch (context->config.debugger) {
+        case Config::DEBUGGER_GDB:
+            cmd = "which gdb";
+            break;
+        case Config::DEBUGGER_LLDB:
+            cmd = "which lldb";
+            break;
+        }
+
         FILE *output = popen(cmd.c_str(), "r");
         if (output != NULL) {
             std::array<char,256> buf;
             fgets(buf.data(), buf.size(), output);
             int ret = pclose(output);
             if (ret != 0) {
-                critical(QString("Trying to start a game with attached gdb, but gdb cannot be found"), context->interactive);
+                critical(QString("Trying to start a game with attached debugger, but debugger cannot be found"), context->interactive);
                 return false;
             }
         }
         else {
-            critical(QString("Coundn't popen to locate gdb"), context->interactive);
+            critical(QString("Coundn't popen to locate debugger"), context->interactive);
             return false;
         }
     }

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -820,6 +820,11 @@ void MainWindow::createMenus()
 
     debugMenu->addSeparator();
 
+    sigintAction = debugMenu->addAction(tr("Raise SIGINT upon game launch (if debugging)"));
+    sigintAction->setCheckable(true);
+
+    debugMenu->addSeparator();
+
     debugMenu->addActions(loggingOutputGroup->actions());
     disabledActionsOnStart.append(loggingOutputGroup->actions());
 
@@ -1352,6 +1357,8 @@ void MainWindow::slotLaunch(bool attach_gdb)
     setListFromRadio(channelGroup, context->config.sc.audio_channels);
 
     setListFromRadio(loggingOutputGroup, context->config.sc.logging_status);
+
+    context->config.sc.sigint_upon_launch = context->attach_gdb && sigintAction->isChecked();
 
     context->config.sc.mouse_support = mouseAction->isChecked();
     setListFromRadio(joystickGroup, context->config.sc.nb_controllers);

--- a/src/program/ui/MainWindow.h
+++ b/src/program/ui/MainWindow.h
@@ -124,6 +124,7 @@ public:
     QActionGroup *asyncGroup;
 
     QActionGroup *debugStateGroup;
+    QAction *sigintAction;
     QActionGroup *loggingOutputGroup;
     QActionGroup *loggingPrintGroup;
     QActionGroup *loggingExcludeGroup;

--- a/src/program/ui/MainWindow.h
+++ b/src/program/ui/MainWindow.h
@@ -31,6 +31,7 @@
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QComboBox>
+#include <QtWidgets/QToolButton>
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QTimer>
 #include <forward_list>
@@ -169,7 +170,9 @@ public:
     QSpinBox *initialTimeNsec;
 
     QPushButton *launchButton;
-    QPushButton *launchGdbButton;
+    QToolButton *launchGdbButton;
+    QAction *launchGdbAction;
+    QAction *launchLldbAction;
     QPushButton *stopButton;
 
     QGroupBox *movieBox;
@@ -236,7 +239,9 @@ private slots:
     /* Update framerate values */
     void updateFramerate();
 
-    void slotLaunch();
+    void slotLaunchGdb();
+    void slotLaunchLldb();
+    void slotLaunch(bool attach_gdb);
     void slotStop();
     void slotBrowseGamePath();
     void slotGamePathChanged();

--- a/src/shared/SharedConfig.h
+++ b/src/shared/SharedConfig.h
@@ -295,6 +295,9 @@ struct __attribute__((packed, aligned(8))) SharedConfig {
 
     /* Send stack traces of all time calls to libTAS program */
     bool time_trace = false;
+
+    /* Call raise(SIGINT) in libtas::init */
+    bool sigint_upon_launch = false;
 };
 
 #endif


### PR DESCRIPTION
The first commit:

The "Launch with GDB" button has a dropdown where you can select to use either gdb or lldb.

![image](https://user-images.githubusercontent.com/10761079/124456987-9d0d0180-dd8b-11eb-993a-c5d590f6fae2.png)

The choice of whether to use gdb or lldb is stored the global libTAS.ini configuration file.

---

The second commit:

Adds a "Raise SIGINT upon game launch" option that makes `libtas::main` call `raise(SIGINT)` after connecting to libTAS. Useful for setting breakpoints and similar.