### PR TITLE
Disable launching debugger if STDIN is not a TTY

### DIFF
--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -58,7 +58,7 @@
 #include <future>
 #include <sys/stat.h>
 #include <csignal> // kill
-#include <unistd.h> // access
+#include <unistd.h> // access, isatty
 #include <limits>
 #include <features.h> // __GLIBC_PREREQ
 
@@ -237,6 +237,10 @@ MainWindow::MainWindow(Context* c) : QMainWindow(), context(c)
 
     launchGdbAction = new QAction(tr("Launch with GDB"), this);
     launchLldbAction = new QAction(tr("Launch with LLDB"), this);
+    if (!isatty(STDIN_FILENO)) {
+        launchGdbAction->setEnabled(false);
+        launchLldbAction->setEnabled(false);
+    }
 
     connect(launchGdbAction, &QAction::triggered, this, &MainWindow::slotLaunchGdb);
     connect(launchLldbAction, &QAction::triggered, this, &MainWindow::slotLaunchLldb);


### PR DESCRIPTION
This disables being able to use the "Launch with GDB" or "Launch with LLDB" button if libTAS is not attached to a terminal.

Otherwise, a user who doesn't know any better could try to launch with a debugger, and then get confused when they don't see anything noticeably different - which is bad when closing the game doesn't close the debugger, so if they did it over and over they'd have a ton of zombie processes on their system.

At least one user in the libTAS Discord server has fallen victim to this.