### PR TITLE
Use SA_SIGINFO / sa_sigaction for the checkpoint signal handler.

### DIFF
--- a/src/library/checkpoint/Checkpoint.cpp
+++ b/src/library/checkpoint/Checkpoint.cpp
@@ -277,7 +277,7 @@ int Checkpoint::checkRestore()
     return SaveStateManager::ESTATE_OK;
 }
 
-void Checkpoint::handler(int signum)
+void Checkpoint::handler(int signum, siginfo_t *info, void *ucontext)
 {
 #ifdef __unix__
     /* Check that we are using our alternate stack by looking at the address

--- a/src/library/checkpoint/Checkpoint.h
+++ b/src/library/checkpoint/Checkpoint.h
@@ -23,6 +23,7 @@
 #define LIBTAS_CHECKPOINT_H
 
 #include <string>
+#include <signal.h> // siginfo_t
 
 namespace libtas {
 namespace Checkpoint
@@ -37,7 +38,7 @@ namespace Checkpoint
 
     int checkCheckpoint();
     int checkRestore();
-    void handler(int signum);
+    void handler(int signum, siginfo_t *info, void *ucontext);
 }
 }
 

--- a/src/library/checkpoint/SaveStateManager.cpp
+++ b/src/library/checkpoint/SaveStateManager.cpp
@@ -92,8 +92,8 @@ void SaveStateManager::initCheckpointThread()
 
     struct sigaction sigcheckpoint;
     sigfillset(&sigcheckpoint.sa_mask);
-    sigcheckpoint.sa_flags = SA_ONSTACK;
-    sigcheckpoint.sa_handler = Checkpoint::handler;
+    sigcheckpoint.sa_flags = SA_ONSTACK | SA_SIGINFO;
+    sigcheckpoint.sa_sigaction = Checkpoint::handler;
     {
         GlobalNative gn;
         MYASSERT(sigaction(sig_checkpoint, &sigcheckpoint, nullptr) == 0)


### PR DESCRIPTION
This ensures that the machine context of the signal will be saved and put somewhere where libTAS can save and restore it. This is typically not an actual issue, as long as the stack pointer is correct then on restore it will just return to after the saving signal raise. However, if the stack pointer is wrong (bad luck?), then it will just return to garbage and most likely crash immediately.

I have some suspicions that https://github.com/clementgallet/libTAS/issues/522 and https://github.com/clementgallet/libTAS/issues/434 are related to this, but it's possible those are just separate issues here.