### PR TITLE
Fix readelf usage when the game path has spaces in it.

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -477,7 +477,7 @@ bool GameLoop::startFrameMessages()
             std::string sym = receiveString();
             
             std::ostringstream cmd;
-            cmd << "readelf -Ws " << context->gamepath << " | grep " << sym << " | awk '{print $2}'";
+            cmd << "readelf -Ws '" << context->gamepath << "' | grep " << sym << " | awk '{print $2}'";
 
             FILE *addrstr = popen(cmd.str().c_str(), "r");
             uint64_t addr = 0;


### PR DESCRIPTION
This fixes an issue noticed in #531, refer to https://github.com/clementgallet/libTAS/issues/531#issuecomment-1531139442 for details.