### PR TITLE
Arma CWA Timing Setting

### DIFF
--- a/src/library/checkpoint/ThreadManager.cpp
+++ b/src/library/checkpoint/ThreadManager.cpp
@@ -120,12 +120,18 @@ void ThreadManager::setMainThread()
     }
 
     if (main_pthread_id != pthread_id) {
-        if (!(Global::shared_config.debug_state & SharedConfig::DEBUG_MAIN_FIRST_THREAD)) {
+        if (!(Global::shared_config.debug_state & SharedConfig::DEBUG_MAIN_FIRST_THREAD) &&
+            !(Global::shared_config.game_specific_timing & SharedConfig::GC_TIMING_ARMA_CWA)) {
             /* Switching main thread */
             debuglogstdio(LCF_THREAD | LCF_WARNING, "Switching main thread from %d to %d", main_pthread_id, pthread_id);
             main_pthread_id = pthread_id;
         }
     }
+}
+
+void ThreadManager::setMainThread(pthread_t pthread_id)
+{
+    main_pthread_id = pthread_id;
 }
 
 void ThreadManager::setCheckpointThread()

--- a/src/library/checkpoint/ThreadManager.h
+++ b/src/library/checkpoint/ThreadManager.h
@@ -51,6 +51,9 @@ void restoreThreadTids();
 /* Set the main thread to this thread */
 void setMainThread();
 
+/* Set the main thread to the provided thread */
+void setMainThread(pthread_t pthread_id);
+
 /* Check if this thread is main thread */
 bool isMainThread();
 

--- a/src/library/pthreadwrappers.cpp
+++ b/src/library/pthreadwrappers.cpp
@@ -753,6 +753,12 @@ int pthread_setname_np (const char *name)
         }
     }
 
+    if (Global::shared_config.game_specific_timing & SharedConfig::GC_TIMING_ARMA_CWA) {
+        if (strcmp(name, "G.Main") == 0) {
+            ThreadManager::setMainThread(target_thread);
+        }
+    }
+
 #ifdef __unix__
     return orig::pthread_setname_np(target_thread, name);
 #elif defined(__APPLE__) && defined(__MACH__)

--- a/src/program/ui/settings/GameSpecificPane.cpp
+++ b/src/program/ui/settings/GameSpecificPane.cpp
@@ -37,10 +37,12 @@ void GameSpecificPane::initLayout()
 {
     /* Timing settings */
     timingCeleste = new ToolTipCheckBox("Celeste");
+    timingArmaCwa = new ToolTipCheckBox("Arma Cold War Assault");
 
     timingGroupBox = new QGroupBox(tr("Timing settings"));
     QVBoxLayout *timingLayout = new QVBoxLayout;
     timingLayout->addWidget(timingCeleste);
+    timingLayout->addWidget(timingArmaCwa);
     timingGroupBox->setLayout(timingLayout);
 
     /* Sync settings */
@@ -66,6 +68,7 @@ void GameSpecificPane::initLayout()
 void GameSpecificPane::initSignals()
 {
     connect(timingCeleste, &QCheckBox::toggled, this, &GameSpecificPane::saveConfig);
+    connect(timingArmaCwa, &QCheckBox::toggled, this, &GameSpecificPane::saveConfig);
     connect(syncCeleste, &QCheckBox::toggled, this, &GameSpecificPane::saveConfig);
     connect(syncWitness, &QCheckBox::toggled, this, &GameSpecificPane::saveConfig);
 }
@@ -75,6 +78,10 @@ void GameSpecificPane::initToolTips()
     timingCeleste->setTitle("Celeste Timing");
     timingCeleste->setDescription("Fake advance the timer on <code>sched_yield()</code> "
     "calls so that the game does not softlock.");
+
+    timingArmaCwa->setTitle("Arma Cold War Assault Timing");
+    timingArmaCwa->setDescription("Set the thread named \"G.Main\" as the main thread. "
+    "This prevents a softlock as long as clock_gettime() monotonic time tracking is enabled.");
 
     syncCeleste->setTitle("Celeste Sync");
     syncCeleste->setDescription("Pause the main thread, waiting for threads with "
@@ -94,6 +101,7 @@ void GameSpecificPane::showEvent(QShowEvent *event)
 void GameSpecificPane::loadConfig()
 {
     timingCeleste->setChecked(context->config.sc.game_specific_timing & SharedConfig::GC_TIMING_CELESTE);
+    timingArmaCwa->setChecked(context->config.sc.game_specific_timing & SharedConfig::GC_TIMING_ARMA_CWA);
     syncCeleste->setChecked(context->config.sc.game_specific_sync & SharedConfig::GC_SYNC_CELESTE);
     syncWitness->setChecked(context->config.sc.game_specific_sync & SharedConfig::GC_SYNC_WITNESS);
 }
@@ -102,6 +110,7 @@ void GameSpecificPane::saveConfig()
 {
     context->config.sc.game_specific_timing = 0;
     context->config.sc.game_specific_timing |= timingCeleste->isChecked()? SharedConfig::GC_TIMING_CELESTE : 0;
+    context->config.sc.game_specific_timing |= timingArmaCwa->isChecked()? SharedConfig::GC_TIMING_ARMA_CWA : 0;
 
     context->config.sc.game_specific_sync = 0;
     context->config.sc.game_specific_sync |= syncCeleste->isChecked()? SharedConfig::GC_SYNC_CELESTE : 0;

--- a/src/program/ui/settings/GameSpecificPane.h
+++ b/src/program/ui/settings/GameSpecificPane.h
@@ -46,6 +46,7 @@ private:
     QGroupBox *syncGroupBox;
     
     ToolTipCheckBox *timingCeleste;
+    ToolTipCheckBox *timingArmaCwa;
     ToolTipCheckBox *syncCeleste;
     ToolTipCheckBox *syncWitness;
 

--- a/src/shared/SharedConfig.h
+++ b/src/shared/SharedConfig.h
@@ -247,6 +247,7 @@ struct __attribute__((packed, aligned(8))) SharedConfig {
     enum GameSpecificTiming
     {
         GC_TIMING_CELESTE = 0x01,
+        GC_TIMING_ARMA_CWA = 0x02,
     };
 
     /* Game-specific timing settings */


### PR DESCRIPTION
Allows for the correct thread to be marked as the main thread.