### PR TITLE
Add SDL_WINDOWEVENT_SIZE_CHANGED to the banned SDL2 events

### DIFF
--- a/src/library/sdl/sdlevents.cpp
+++ b/src/library/sdl/sdlevents.cpp
@@ -81,6 +81,7 @@ static bool isBannedEvent(SDL_Event *event)
                 case SDL_WINDOWEVENT_ENTER:
                 case SDL_WINDOWEVENT_LEAVE:
                 case SDL_WINDOWEVENT_TAKE_FOCUS:
+                case SDL_WINDOWEVENT_SIZE_CHANGED:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
This event seems to be able to just cause crashes (test case being Arma Cold War Assault, which triggers the event a few frames into execution and crashes due to it). I'm not sure if this is a proper fix, nor do I really understand why a crash occurs due to this event. It could be due to it invalidating the SDL GL Context (setting it to NULL) and that causing conflicts with libTAS's wrappers, maybe?