### PR TITLE
Implement AL_SOFT_buffer_sub_data support

### DIFF
--- a/src/library/audio/openal/al.h
+++ b/src/library/audio/openal/al.h
@@ -293,6 +293,10 @@ typedef void ALvoid;
 #define AL_STREAMING                             0x1029
 #define AL_UNDETERMINED                          0x1030
 
+/** AL_SOFT_buffer_sub_data extension */
+#define AL_BYTE_RW_OFFSETS_SOFT                  0x1031
+#define AL_SAMPLE_RW_OFFSETS_SOFT                0x1032
+
 /** Buffer format specifier. */
 #define AL_FORMAT_MONO8                          0x1100
 #define AL_FORMAT_MONO16                         0x1101
@@ -533,6 +537,9 @@ OVERRIDE void alGetListenerfv(ALenum param, ALfloat *values);
 OVERRIDE void alGetListeneri(ALenum param, ALint *value);
 OVERRIDE void alGetListener3i(ALenum param, ALint *v1, ALint *v2, ALint *v3);
 OVERRIDE void alGetListeneriv(ALenum param, ALint *values);
+
+/** Override some protected OpenAL functions */
+void hook_openal();
 
 }
 

--- a/src/library/main.cpp
+++ b/src/library/main.cpp
@@ -34,6 +34,7 @@
 #include "checkpoint/SaveStateManager.h"
 #include "checkpoint/Checkpoint.h"
 #include "audio/AudioContext.h"
+#include "audio/openal/al.h"
 #include "encoding/AVEncoder.h"
 #include <unistd.h> // getpid()
 #include "frame.h" // framecount
@@ -193,6 +194,7 @@ void __attribute__((constructor)) init(void)
     audiocontext.init();
 
     hook_mono();
+    hook_openal();
 
     Global::is_inited = true;
 }


### PR DESCRIPTION
This is require for Arma CWA for its dialog and music, and to avoid a crash due to AL_BYTE_RW_OFFSETS_SOFT not being responded to. The audio doesn't work for that game however, due to its heavy reliance on 3D audio functions which libTAS does not implement. These changes are somewhat naive, as this extension is deprecated and no longer actually used as it conflicts with the AL_SOURCE_RADIUS_EXT extension (due to overlapping enum with AL_BYTE_RW_OFFSETS_SOFT). Although that bridge could be crossed when it comes to it.