### PR TITLE
Fix open_audio_device()

### DIFF
--- a/src/library/audio/sdl/sdlaudio.cpp
+++ b/src/library/audio/sdl/sdlaudio.cpp
@@ -107,6 +107,8 @@ char * SDL_AudioDriverName(char *namebuf, int maxlen)
 /* Helper function for SDL_OpenAudio() and SDL_OpenAudioDevice() */
 static int open_audio_device(const SDL_AudioSpec * desired, SDL_AudioSpec * obtained, int min_id)
 {
+    SDL_AudioSpec _obtained;
+
     if (Global::shared_config.audio_disabled)
         return -1;
 
@@ -121,10 +123,11 @@ static int open_audio_device(const SDL_AudioSpec * desired, SDL_AudioSpec * obta
         return -1;
     }
 
-    if (obtained != NULL) {
-        memcpy(obtained, desired, sizeof(SDL_AudioSpec));
+    if (!obtained) {
+        obtained = &_obtained;
     }
 
+    memcpy(obtained, desired, sizeof(SDL_AudioSpec));
     std::lock_guard<std::mutex> lock(audiocontext.mutex);
 
     int bufferId = audiocontext.createBuffer();

--- a/src/library/audio/sdl/sdlaudio.cpp
+++ b/src/library/audio/sdl/sdlaudio.cpp
@@ -122,7 +122,7 @@ static int open_audio_device(const SDL_AudioSpec * desired, SDL_AudioSpec * obta
     }
 
     if (obtained != NULL) {
-        memmove(obtained, desired, sizeof(SDL_AudioSpec));
+        memcpy(obtained, desired, sizeof(SDL_AudioSpec));
     }
 
     std::lock_guard<std::mutex> lock(audiocontext.mutex);

--- a/src/library/audio/sdl/sdlaudio.cpp
+++ b/src/library/audio/sdl/sdlaudio.cpp
@@ -134,12 +134,12 @@ static int open_audio_device(const SDL_AudioSpec * desired, SDL_AudioSpec * obta
     auto buffer = audiocontext.getBuffer(bufferId);
 
     /* Sanity check done by SDL */
-    if (!obtained->freq) obtained->freq = 22050;
+    if (desired->freq == 0) obtained->freq = 22050;
     buffer->frequency = obtained->freq;
     debuglogstdio(LCF_SDL | LCF_SOUND, "Frequency %d Hz", buffer->frequency);
 
     /* Sanity check done by SDL */
-    if (!obtained->format) obtained->format = AUDIO_S16LSB;
+    if (desired->format == 0) obtained->format = AUDIO_S16LSB;
 
     switch(obtained->format) {
         case AUDIO_U8:
@@ -159,7 +159,7 @@ static int open_audio_device(const SDL_AudioSpec * desired, SDL_AudioSpec * obta
             return -1;
     }
     /* Sanity check done by SDL */
-    if (!obtained->channels) obtained->channels = 2;
+    if (desired->channels == 0) obtained->channels = 2;
     buffer->nbChannels = obtained->channels;
     debuglogstdio(LCF_SDL | LCF_SOUND, "Channels %d", buffer->nbChannels);
 


### PR DESCRIPTION
The libTAS implementation of this function was failing to account for the situation where the `obtained` parameter is a null pointer. In this situation, what SDL does it simply create a local variable, so I have replicated that functionality here. In addition, SDL finds it suitable to use `memcpy` instead of `memmove`, so I thought it would make sense to do the same, as it increases performance, and specifying the same pointer for both `obtained` and `desired` would be nonsensical anyway. These changes fix broken audio in LIMBO and probably other games too.