### PR TITLE
Directly use ucontext passed in signal handler instead of trying to copy the current stack frame.

### DIFF
--- a/src/library/checkpoint/AltStack.cpp
+++ b/src/library/checkpoint/AltStack.cpp
@@ -35,13 +35,6 @@ namespace libtas {
  */
 static stack_t oss;
 
-/* We must save the last stack frame of the alternate stack in the savestate, so
- * that we return at the correct location from the alternate stack.
- */
-#define STACKFRAME_OFFSET 0x700
-#define STACKFRAME_SIZE 0x700
-static uint8_t stack_frame[STACKFRAME_SIZE];
-
 void AltStack::saveStack()
 {
     int ret;
@@ -68,21 +61,6 @@ void AltStack::restoreStack()
     int ret;
     NATIVECALL(ret = sigaltstack(&oss, nullptr));
     MYASSERT(ret == 0)
-}
-
-void AltStack::saveStackFrame()
-{
-    /* Does not work in MacOS yet */
-#ifdef __unix__
-    memcpy(stack_frame, ReservedMemory::getAddr(ReservedMemory::STACK_ADDR + ReservedMemory::STACK_SIZE - STACKFRAME_OFFSET), STACKFRAME_SIZE);
-#endif
-}
-
-void AltStack::restoreStackFrame()
-{
-#ifdef __unix__
-    memcpy(ReservedMemory::getAddr(ReservedMemory::STACK_ADDR + ReservedMemory::STACK_SIZE - STACKFRAME_OFFSET), stack_frame, STACKFRAME_SIZE);
-#endif
 }
 
 }

--- a/src/library/checkpoint/AltStack.h
+++ b/src/library/checkpoint/AltStack.h
@@ -28,9 +28,6 @@ namespace AltStack
     void saveStack();
     void prepareStack();
     void restoreStack();
-
-    void saveStackFrame();
-    void restoreStackFrame();
 }
 }
 

--- a/src/library/checkpoint/Checkpoint.h
+++ b/src/library/checkpoint/Checkpoint.h
@@ -23,6 +23,7 @@
 #define LIBTAS_CHECKPOINT_H
 
 #include <string>
+#include <signal.h> // siginfo_t
 
 namespace libtas {
 namespace Checkpoint
@@ -37,7 +38,7 @@ namespace Checkpoint
 
     int checkCheckpoint();
     int checkRestore();
-    void handler(int signum);
+    void handler(int signum, siginfo_t *info, void *ucontext);
 }
 }
 


### PR DESCRIPTION
Should be better overall and fix the various stack smashing issues.

I guess supersedes #532 (as SA_SIGINFO / sa_sigaction needs to be used to access the ucontext pointer).