### PR TITLE
make OSD report branch loading

### DIFF
--- a/src/program/SaveState.cpp
+++ b/src/program/SaveState.cpp
@@ -37,7 +37,7 @@ void SaveState::init(Context* context, int i)
     movie = std::unique_ptr<MovieFile>(new MovieFile(context));
 
     buildPaths(context);
-    buildMessages(context);
+    buildMessages();
 }
 
 void SaveState::invalidate()
@@ -68,7 +68,7 @@ void SaveState::buildPaths(Context* context)
     }
 }
 
-void SaveState::buildMessages(Context* context)
+void SaveState::buildMessages(bool branch)
 {
     if (saving_msg.empty()) {
         if (is_backtrack) {
@@ -85,25 +85,23 @@ void SaveState::buildMessages(Context* context)
         no_state_msg += std::to_string(id);
     }
 
-    if (loading_msg.empty()) {
-        if (is_backtrack) {
-            loading_msg = "Loading backtrack state";
-        }
-        else {
-            loading_msg = "Loading state ";
-            loading_msg += std::to_string(id);
-        }
+    std::string term = branch ? "branch" : "state";
+
+    if (is_backtrack) {
+        loading_msg = "Loading backtrack " + term;
+    }
+    else {
+        loading_msg = "Loading " + term + " ";
+        loading_msg += std::to_string(id);
     }
 
-    if (loaded_msg.empty()) {
-        if (is_backtrack) {
-            loaded_msg = "Backtrack state loaded";
-        }
-        else {
-            loaded_msg = "State ";
-            loaded_msg += std::to_string(id);
-            loaded_msg += " loaded";
-        }
+    if (is_backtrack) {
+        loaded_msg = "Backtrack " + term + " loaded";
+    }
+    else {
+        loaded_msg = branch ? "Branch " : "State ";
+        loaded_msg += std::to_string(id);
+        loaded_msg += " loaded";
     }
 }
 
@@ -201,6 +199,9 @@ int SaveState::load(Context* context, const MovieFile& m, bool branch)
         }
         return EINVALID;
     }
+
+    /* Rebuild messages to account for a possible branch load */
+    buildMessages(branch);
     
     /* Send the savestate index */
     sendMessage(MSGN_SAVESTATE_INDEX);

--- a/src/program/SaveState.h
+++ b/src/program/SaveState.h
@@ -116,7 +116,7 @@ private:
     std::string loaded_msg;
 
     /* Build all savestate messages */
-    void buildMessages(Context* context);
+    void buildMessages(bool branch = false);
 
 };
 


### PR DESCRIPTION
`buildMessages()` didn't use the `context` argument so I removed it, and replaced with a `branch` flag so that we could rebuild the messages upon every load, because it's unpredictable whether the user will be loading a state or a branch.