### PR TITLE
Lock mutex in XlibEventQueue::insert

### DIFF
--- a/src/library/xlib/XlibEventQueue.cpp
+++ b/src/library/xlib/XlibEventQueue.cpp
@@ -68,6 +68,8 @@ void XlibEventQueue::setMask(Window w, long event_mask)
 
 int XlibEventQueue::insert(XEvent* event)
 {
+    std::lock_guard<std::mutex> lock(mutex);
+
     /* Check if pointer event and pointer is grabbed */
     if ((grab_window != 0) &&
         ((event->type == MotionNotify) || (event->type == ButtonPress) ||


### PR DESCRIPTION
Probably fixes a rare issue of `free(): invalid pointer` appearing on a `pop_back()` (and just being better wrt thread safety)