### PR TITLE
Ensure that native created threads will be passed the native flag

### DIFF
--- a/src/library/checkpoint/ThreadManager.cpp
+++ b/src/library/checkpoint/ThreadManager.cpp
@@ -183,7 +183,7 @@ ThreadInfo* ThreadManager::getNewThread()
 
     /* No free thread, create a new one */
     if (!thread) {
-        thread = new ThreadInfo;
+        thread = new ThreadInfo();
         debuglogstdio(LCF_THREAD, "Allocate a new ThreadInfo struct");
         threadListChanged = true;
     }


### PR DESCRIPTION
Also make sure ThreadInfo constructions use the correct constructor (new ThreadInfo is analogous to malloc while new ThreadInfo() is analogous to calloc; granted libtas overrides malloc to calloc so this probably doesn't matter in practice, but the compiler probably shouldn't be getting any funny ideas over UB here)