### PR TITLE
input editor window: account for vertical scrollbar width

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,9 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/usr/include/x86_64-linux-gnu/qt5",
-                "/usr/include/lua5.4"
+                "/usr/include/lua5.4",
+                "/usr/include/x86_64-linux-gnu/qt5/QtGui",
+                "/usr/include/x86_64-linux-gnu/qt5/QtWidgets"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
 			"label": "configure",
 			"command": "./configure",
 			"args": [
-				"CXXFLAGS=\"-O2 -g -Wall -pedantic\""
+				"CXXFLAGS=\"-Og -g -Wall -pedantic\""
 			],
 			"problemMatcher": []
 		},

--- a/src/program/ui/InputEditorView.cpp
+++ b/src/program/ui/InputEditorView.cpp
@@ -99,6 +99,8 @@ InputEditorView::InputEditorView(Context* c, QWidget *parent, QWidget *gp) : QTa
     keyDialog->withModifiers = false;
 
     currentMarkerText = "";
+
+    scrollBarWidth = verticalScrollBar()->sizeHint().width() + 20;
 }
 
 void InputEditorView::fillMenu(QMenu* frameMenu)

--- a/src/program/ui/InputEditorView.h
+++ b/src/program/ui/InputEditorView.h
@@ -40,6 +40,7 @@ public:
     void update();
     void resetInputs();
     InputEditorModel *inputEditorModel;
+    int scrollBarWidth;
 
 public slots:
     void horizontalMenu(QPoint pos);

--- a/src/program/ui/InputEditorWindow.cpp
+++ b/src/program/ui/InputEditorWindow.cpp
@@ -71,7 +71,7 @@ void InputEditorWindow::update_config()
 QSize InputEditorWindow::sizeHint() const
 {
     QSize viewSize = inputEditorView->sizeHint();
-    return QSize(viewSize.width(), 600);
+    return QSize(viewSize.width() + inputEditorView->scrollBarWidth, 600);
 }
 
 void InputEditorWindow::resetInputs()


### PR DESCRIPTION
Input editor window was always hiding a part of the last column for me and had a horizontal scrollbar because it was always a few pixels too narrow. Using scrollbar width alone didn't help, I had to add 10 pixels to it, and then added 10 more to be extra safe.

Also added more qt include paths for vscode and switched to `-Og` build flag.