### PR TITLE
Delay SDL2 GL screen capture init until swap

### DIFF
--- a/src/library/sdl/sdlwindows.cpp
+++ b/src/library/sdl/sdlwindows.cpp
@@ -96,6 +96,11 @@ static bool windowFullscreen = false;
 
     DEBUGLOGCALL(LCF_SDL | LCF_OGL | LCF_WINDOW);
 
+    /* Games are sometimes tricky with their GL context management
+     * Initing screen capture here ensures the GL context used for
+     * swapping the game window will be captured */
+    ScreenCapture::init();
+
     /* Start the frame boundary and pass the function to draw */
     static RenderHUD_GL renderHUD_GL;
     frameBoundary([&] () {orig::SDL_GL_SwapWindow(window);}, renderHUD_GL);
@@ -122,9 +127,6 @@ void* SDL_GL_CreateContext(SDL_Window *window)
     if (!context) {
         return context;
     }
-
-    /* Now that the context is created, we can init the screen capture */
-    ScreenCapture::init();
 
 #ifdef __unix__
     /* Alerting the user if software rendering is not active */


### PR DESCRIPTION
Games can be tricky with GL context management. Arma CWA seems to be an evil game in particular here, ending up creating 11 different GL contexts (seemingly just for messing around with attributes?), 10 of which get deleted shortly after use. The 5th context created by this game ends up being the one actually used for rendering / swapping the window. When screen capture was init on context creation, this just resulted in screen capture being uninit for the game. With screen capture init at swapping buffers, this is no longer the case and screen capture works perfectly fine.