### PR TITLE
Use the correct ucontext definition for checkpoint signal handler and properly checkpoint floating point state

### DIFF
--- a/src/library/checkpoint/Checkpoint.cpp
+++ b/src/library/checkpoint/Checkpoint.cpp
@@ -62,10 +62,19 @@
 #ifdef __linux__
 #include <sys/syscall.h>
 #endif
+#ifdef __linux__
+/* The ucontext passed to the signal handler is from <asm/ucontext.h> rather than <ucontext.h>
+ * This is due to the ucontext in this instance being allocated kernel side
+ * The kernel does not care for the libc ucontext definition, only its own (generally smaller) baseline definition
+ */
+#include <asm/ucontext.h>
+#define ucontext_t ucontext
+#else
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
 #endif
 #include <ucontext.h>
+#endif
 
 #define ONE_MB 1024 * 1024
 


### PR DESCRIPTION
The ucontext here is allocated on the linux kernel size, and thus it does not necessarily have the same size as the libc ucontext libc ucontext may be extended compared to the baseline linux ucontext, and thus the actual size of the passed ucontext might be smaller In practice, this usually isn't an issue, as these are ultimately stack allocated (in the alt stack), and there's typically plenty of room available. Regardless, this still doesn't make it immune to possible issues.

As a side issue, the floating point state in the ucontext is not in the ucontext directly, but rather it's in another buffer accessed by a pointer (libc extends ucontext to store it in the ucontext itself, but the kernel doesn't do this). In practice, this pointer *probably* doesn't change, since it's just a pointer to the alt stack, although saving/restoring the fp state regardless needs to be done via this pointer and it should remain unchanged when restoring the state.