### PR TITLE
Fix joystick axes added to Input Editor when not used

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -720,11 +720,15 @@ void GameLoop::processInputs(AllInputs &ai)
                 if (ai.controllers[j]) {
                     emit fillControllerInputs(*ai.controllers[j], j);            
                 }
-                else {
+                else if (j < context->config.sc.nb_controllers) {
                     /* If we didn't created an object yet, but if the user
                      * did set something on the controller panel, then create
                      * the object. */
                     ControllerInputs ci;
+                    /* Clear the controller inputs incase the joystick input editor
+                     * is not open to prevent it from reading garbade data
+                     * and adding the joystick axes to the input editor. */
+                    ci.clear();
                     emit fillControllerInputs(ci, j);
                     if (!ci.isDefaultController())
                         ai.controllers[j].reset(new ControllerInputs(ci));


### PR DESCRIPTION
The added if condition is not really necessary, but though it would make sense to limit adding new controllers to the amount that is was set in the input settings.