### PR TITLE
Prefer liblua5.4 on dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: libtas
 Section: unknown
 Priority: optional
 Maintainer: Clement Gallet <clement.gallet@ens-lyon.org>
-Build-Depends: debhelper-compat (= 10), libx11-dev, qtbase5-dev (>= 5.6.0), libsdl2-dev, libxcb1-dev, libxcb-keysyms1-dev, libxcb-xinput-dev, libxcb-xkb-dev, libx11-xcb-dev, libasound2-dev, libavutil-dev, liblua5.3-dev | liblua5.4-dev, libswresample-dev
+Build-Depends: debhelper-compat (= 10), libx11-dev, qtbase5-dev (>= 5.6.0), libsdl2-dev, libxcb1-dev, libxcb-keysyms1-dev, libxcb-xinput-dev, libxcb-xkb-dev, libx11-xcb-dev, libasound2-dev, libavutil-dev, liblua5.4-dev | liblua5.3-dev, libswresample-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/clementgallet/libTAS
 
 Package: libtas
 Architecture: any
-Depends: libasound2 (>= 1.0.16), libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0), libqt5gui5 (>= 5.6.0), libqt5widgets5 (>= 5.6.0), libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xinput0, libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.3-0 | liblua5.4-0, ffmpeg
+Depends: libasound2 (>= 1.0.16), libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0), libqt5gui5 (>= 5.6.0), libqt5widgets5 (>= 5.6.0), libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xinput0, libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.4-0 | liblua5.3-0, ffmpeg
 Description: A program to provide tool-assisted speedrun tools to Linux games


### PR DESCRIPTION
Since 8ca2a2a I believe the interim versions are being built with liblua5.4, but the dependencies default to 5.3, which causes the need to install 5.4 manually.