### PR TITLE
Add Terminal=true to .desktop

### DIFF
--- a/libTAS.desktop
+++ b/libTAS.desktop
@@ -5,3 +5,4 @@ Comment=Tool-assisted speedrunning tool for native games
 Exec=libTAS
 Icon=libTAS
 Categories=Utility;
+Terminal=true


### PR DESCRIPTION
Recently learned this was a thing. I think it's always desirable to launch libTAS with the terminal due to the logging.