### PR TITLE
Fixes for GL Screen Capture

### DIFF
--- a/src/library/rendering/openglloader.h
+++ b/src/library/rendering/openglloader.h
@@ -63,6 +63,7 @@ struct GLProcs {
     DEFINE_GL_POINTER(GenFramebuffers)
     DEFINE_GL_POINTER(BindFramebuffer)
     DEFINE_GL_POINTER(DeleteFramebuffers)
+    DEFINE_GL_POINTER(GetFramebufferAttachmentParameteriv)
     DEFINE_GL_POINTER(GenRenderbuffers)
     DEFINE_GL_POINTER(BindRenderbuffer)
     DEFINE_GL_POINTER(DeleteRenderbuffers)


### PR DESCRIPTION
This consists of 2 main fixes:
1. Set the screen capture texture so an SRGB texture if the default framebuffer is sRGB. This is a better fix than disabling GL_FRAMEBUFFER_SRGB (which just disables sRGB to linear and vice versa conversions), as it still prevents conversions being done (and thus has glReadPixels, which never does a conversion and thus can't invert a sRGB -> linear RGB conversion, produce the correct result), and it ensures when ImGui uses the texture, it will correctly use the sRGB contents instead of reinterpreting them as linear RGB (this mainly shows up as an issue with Ruffle when detaching the game window, where the colors look washed out).
2. Disable scissor test for relevant screen capture operations. This probably doesn't actually do much in practice, but the scissor test is still used for blitting framebuffers and clearing, so best disable it so the entire screen is captured/cleared.

Also does a minor fix preventing a potential leak with screenTex, although in practice I'm not sure if this is ever an issue (a similar pattern exists for other gl resources however).