### PR TITLE
Update dependencies to support libswresample5

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can download the latest stable version of the software in the [Releases](htt
 * `liblua5.4-0`
 * `ffmpeg`
 * `file`
-* `libswresample2` or `libswresample3` or `libswresample4`, `libasound2`
+* `libswresample2` or `libswresample3` or `libswresample4` or `libswresample5`, `libasound2`
 
 Installing with the debian package will install all the required packages as well.
 

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/clementgallet/libTAS
 
 Package: libtas
 Architecture: any
-Depends: libasound2 (>= 1.0.16), libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0), libqt5gui5 (>= 5.6.0), libqt5widgets5 (>= 5.6.0), libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xinput0, libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.4-0, ffmpeg
+Depends: libasound2 (>= 1.0.16), libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0), libqt5gui5 (>= 5.6.0), libqt5widgets5 (>= 5.6.0), libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4 | libswresample5, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xinput0, libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.4-0, ffmpeg
 Description: A program to provide tool-assisted speedrun tools to Linux games

--- a/src/library/audio/AudioConverterSwr.cpp
+++ b/src/library/audio/AudioConverterSwr.cpp
@@ -55,6 +55,7 @@ AudioConverterSwr::AudioConverterSwr(void)
     {
         GlobalNoLog gnl;
         LINK_NAMESPACE(swr_alloc, "swresample");
+        LINK_NAMESPACE_FULLNAME(swr_alloc, "libswresample.so.5");
         LINK_NAMESPACE_FULLNAME(swr_alloc, "libswresample.so.4");
         LINK_NAMESPACE_FULLNAME(swr_alloc, "libswresample.so.3");
         LINK_NAMESPACE_FULLNAME(swr_alloc, "libswresample.so.2");


### PR DESCRIPTION
This PR updates the dependency list and README to support libswresample5, the latest version of libswresample, now available in the apt registry for Ubuntu 24+.