### PR TITLE
Add missing <cstdint> include to AVEncoder.h

### DIFF
--- a/src/library/encoding/AVEncoder.h
+++ b/src/library/encoding/AVEncoder.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <memory> // std::unique_ptr
+#include <cstdint>
 
 namespace libtas {
 


### PR DESCRIPTION
same issue as https://github.com/clementgallet/libTAS/pull/539, now in `AVEncoder.h`