### PR TITLE
fix: ignore `.cache/mesa_shader_cache_db` entries

### DIFF
--- a/src/library/fileio/SaveFileList.cpp
+++ b/src/library/fileio/SaveFileList.cpp
@@ -143,7 +143,7 @@ bool isSaveFile(const char *file)
         return false;
 
     /* We don't need to keep mesa shader cache files */
-    if (strstr(file, "/.cache/mesa_shader_cache/"))
+    if (strstr(file, "/.cache/mesa_shader_cache"))
         return false;
 
     return true;


### PR DESCRIPTION
I was getting a bunch of 
```
[f:0 t:22304M] INFO: Open a savefile from /home/jakob/.cache/mesa_shader_cache_db/part18/mesa_cache.idx
[f:0 t:22304M] INFO: Open a savefile from /home/jakob/.cache/mesa_shader_cache_db/part19/mesa_cache.idx
[f:0 t:22304M] INFO: Open a savefile from /home/jakob/.cache/mesa_shader_cache_db/part20/mesa_cache.idx
[f:0 t:22304M] INFO: Open a savefile from /home/jakob/.cache/mesa_shader_cache_db/part21/mesa_cache.idx
```

Looks like mesa has switched from `mesa_shader_cache` to `mesa_shader_cache_db`, so with this change both get properly ignored.