### PR TITLE
Skip saving lightweight guard pages

### DIFF
--- a/src/library/checkpoint/Checkpoint.cpp
+++ b/src/library/checkpoint/Checkpoint.cpp
@@ -727,9 +727,14 @@ static void readAnArea(SaveStateLoading &saved_state, int spmfd, SaveStateLoadin
         if (flag == Area::GUARD_PAGE) {
             pagecount_skip++;
             LOG(LL_DEBUG, LCF_CHECKPOINT, "    Skip reading guard page at %p(isGuardPage=%d)", curAddr);
+            if (!page_guard_region) {
+                LOG(LL_DEBUG, LCF_CHECKPOINT, "    Page was guard page in checkpoint but now isn't");
+                MYASSERT(madvise(curAddr, 4096, MADV_GUARD_INSTALL) == 0);
+            }
             continue;
         } else if (page_guard_region) {
             LOG(LL_DEBUG, LCF_CHECKPOINT, "    Page was not a guard page in checkpoint but now is %p", curAddr);
+            MYASSERT(madvise(curAddr, 4096, MADV_GUARD_REMOVE) == 0);
         }
 
         /* It seems that static memory is both zero and unmapped, so we still

--- a/src/library/checkpoint/Checkpoint.cpp
+++ b/src/library/checkpoint/Checkpoint.cpp
@@ -79,6 +79,13 @@
 
 #define ONE_MB 1024 * 1024
 
+#ifndef MADV_GUARD_INSTALL
+#define MADV_GUARD_INSTALL 102
+#endif
+#ifndef MADV_GUARD_REMOVE
+#define MADV_GUARD_REMOVE 103
+#endif
+
 namespace libtas {
 
 /* Savestate paths (for file storing)*/

--- a/src/library/checkpoint/MemArea.h
+++ b/src/library/checkpoint/MemArea.h
@@ -52,6 +52,7 @@ struct Area {
         BASE_PAGE, /* Page was not modified from base savestate */
         COMPRESSED_PAGE, /* Full page but compressed */
         FILE_PAGE, /* Page is identical to the original mapped file */
+        GUARD_PAGE, /* A page causing a fatal signal on access, without a VMA backing it */
     };
 
     void* addr;


### PR DESCRIPTION
attempts to fix #650 

With this change, creating the savestate works, but restoring still segfaults in

```
#0  0x00007f358feebcbf in LZ4_decompress_generic (src=0x7f358dfbc190 "\037", dst=0x7ffd99ffd000 <error: Cannot access memory at address 0x7ffd99ffd000>, srcSize=55, outputSize=4096, endOnInput=endOnInputSize, partialDecoding=decode_full_block, dict=noDict, lowPrefix=0x7ffd99ffd000 <error: Cannot access memory at address 0x7ffd99ffd000>, dictStart=<optimized out>, dictSize=<optimized out>) at /home/jakob/dev/contrib/libTAS-cmake/src/external/lz4.cpp:1753
#1  LZ4_decompress_safe (source=0x7f358dfbc190 "\037", dest=0x7ffd99ffd000 <error: Cannot access memory at address 0x7ffd99ffd000>, compressedSize=55, maxDecompressedSize=4096) at /home/jakob/dev/contrib/libTAS-cmake/src/external/lz4.cpp:2080
#2  0x00007f358fef5081 in LZ4_decompress_safe_continue (LZ4_streamDecode=0x7f358dfc68a0, source=0x7f358dfbc190 "\037", dest=0x7ffd99ffd000 <error: Cannot access memory at address 0x7ffd99ffd000>, compressedSize=55, maxOutputSize=4096) at /home/jakob/dev/contrib/libTAS-cmake/src/external/lz4.cpp:2237
#3  0x00007f358fe077bc in libtas::SaveStateLoading::queuePageLoad (this=0x7f358dfc53c0, addr=0x7ffd99ffd000 <error: Cannot access memory at address 0x7ffd99ffd000>) at /home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/SaveStateLoading.cpp:231
#4  0x00007f358fdff7ac in libtas::readAnArea (saved_state=..., spmfd=243, parent_state=..., base_state=...) at /home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/Checkpoint.cpp:908
#5  0x00007f358fdfdd65 in libtas::readAllAreas () at /home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/Checkpoint.cpp:430
#6  0x00007f358fdfd697 in libtas::Checkpoint::handler (signum=31, info=0x7f358dffa5b0, ucontext=0x7f358dffa480) at /home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/Checkpoint.cpp:276
#7  <signal handler called>
#8  0x00007f358f69894c in ?? () from /usr/lib/libc.so.6
#9  0x00007f358f63e410 in raise () from /usr/lib/libc.so.6
#10 0x00007f358fe0b593 in libtas::SaveStateManager::checkpoint (slot=3) at /home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/SaveStateManager.cpp:293
```

Trying to read the `[stack]` with addr=0x7ffd99ffd000.

Notable logs from restoring;
```
[f:128 t:71753M] DEBUG: Region 0x7ffd99ffd000 ([stack]) with size 8376320 must be allocated
[f:128 t:71753M] DEBUG: Restoring non-anonymous area, 8376320 bytes at 0x7ffd99ffd000 from [stack] + 0
[f:128 t:71753M] FATAL (/home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/Checkpoint.cpp:607): Mapping 8376320 bytes at 0x7ffd99ffd000 failed: errno 9
[f:128 t:71753M] FATAL (/home/jakob/dev/contrib/libTAS-cmake/src/library/checkpoint/Checkpoint.cpp:611): Area at 0x7ffd99ffd000 got mmapped to 0xffffffffffffffff
```


[save.log](https://github.com/user-attachments/files/21670106/save.log)
https://pastecode.io/s/qretxh5p

[restore.log](https://github.com/user-attachments/files/21670107/restore.log)
https://pastecode.io/s/gaktxrzx