### PR TITLE
Fix Dockerfile: update to Debian 12, update library and missing tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:12
 
 # update
   RUN dpkg --add-architecture i386
@@ -7,7 +7,7 @@ FROM debian:10
 # libtas
   # dependencies
     # main
-      RUN apt-get -y install build-essential automake pkg-config libx11-dev libx11-xcb-dev qtbase5-dev qt5-default libsdl2-dev libxcb1-dev libxcb-keysyms1-dev libxcb-xkb-dev libxcb-cursor-dev libxcb-randr0-dev libudev-dev libasound2-dev libavutil-dev libswresample-dev ffmpeg liblua5.4-dev
+      RUN apt-get -y install build-essential automake pkg-config libx11-dev libx11-xcb-dev qtbase5-dev libsdl2-dev libxcb1-dev libxcb-keysyms1-dev libxcb-xkb-dev libxcb-cursor-dev libxcb-randr0-dev libudev-dev libasound2-dev libavutil-dev libswresample-dev ffmpeg liblua5.4-dev libcap-dev libxcb-xinput-dev
 
     # HUD
       RUN apt-get -y install libfreetype6-dev libfontconfig1-dev
@@ -18,15 +18,15 @@ FROM debian:10
 
     # i386
       RUN apt-get -y install g++-multilib
-      RUN apt-get -y install libx11-6:i386 libx11-dev:i386 libx11-xcb1:i386 libx11-xcb-dev:i386 libasound2:i386 libasound2-dev:i386 libavutil56:i386 libswresample3:i386 libfreetype6:i386 libfreetype6-dev:i386 libfontconfig1:i386 libfontconfig1-dev:i386
+      RUN apt-get -y install libx11-6:i386 libx11-dev:i386 libx11-xcb1:i386 libx11-xcb-dev:i386 libasound2:i386 libasound2-dev:i386 libavutil57:i386 libswresample4:i386 libfreetype6:i386 libfreetype6-dev:i386 libfontconfig1:i386 libfontconfig1-dev:i386
 
 
   # install
-    RUN apt-get -y install git
+    RUN apt-get -y install git wget
     RUN mkdir /root/src
     RUN cd /root/src && git clone https://github.com/clementgallet/libTAS.git
     RUN cd /root/src/libTAS && ./build.sh --with-i386
-    RUN cd /root/src/libTAS && make install
+    RUN cd /root/src/libTAS/build && make install
 
 # additional programs
   # wine
@@ -34,7 +34,7 @@ FROM debian:10
 
   # pcem
     # dependencies
-      RUN apt-get -y install libwxbase3.0-dev libwxgtk3.0-gtk3-dev wx-common libsdl2-dev libopenal-dev
+      RUN apt-get -y install libwxbase3.2 libwxgtk3.2 wx-common libsdl2-dev libopenal-dev
 
     # install
       RUN cd /root/src && git clone https://github.com/TASVideos/pcem.git


### PR DESCRIPTION
Since Debian 10 reached end of life, Dockerfile will no longer work as is.

This MR updates Dockerfile to use Debian 12, and update all broken things in the process.