### PR TITLE
Workaround llvmpipe bug

### DIFF
--- a/src/library/rendering/glxwrappers.cpp
+++ b/src/library/rendering/glxwrappers.cpp
@@ -208,6 +208,7 @@ static void* store_orig_and_return_my_symbol(const GLubyte* symbol, void* real_p
     RETURN_SYMBOL_CUSTOM(glEnable);
     // RETURN_SYMBOL_CUSTOM(glDisable);
     RETURN_SYMBOL_CUSTOM(glViewport);
+    RETURN_SYMBOL_CUSTOM(glGetIntegerv);
 
     return real_pointer;
 }

--- a/src/library/rendering/openglwrappers.cpp
+++ b/src/library/rendering/openglwrappers.cpp
@@ -226,4 +226,29 @@ void myglViewport(GLint x, GLint y, GLsizei width, GLsizei height)
     return glProcs.Viewport(x, y, width, height);
 }
 
+void glGetIntegerv(GLenum pname, GLint *data)
+{
+    LINK_GL_POINTER(GetIntegerv);
+    return myglGetIntegerv(pname, data);
+}
+
+void myglGetIntegerv(GLenum pname, GLint *data)
+{
+    if (GlobalState::isNative()) return glProcs.GetIntegerv(pname, data);
+    LOGTRACE(LCF_OGL);
+    if (Global::shared_config.opengl_soft)
+    {
+        // Unity 4.x uses GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX to determine if there is enough memory for a texture
+        // However, llvmpipe is bugged and will return an uninitialized variable, i.e. non-deterministic
+        // See https://gitlab.freedesktop.org/mesa/mesa/-/issues/14064
+        if (pname == GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX)
+        {
+            *data = 65536;
+            return;
+        }
+    }
+
+    return glProcs.GetIntegerv(pname, data);
+}
+
 }

--- a/src/library/rendering/openglwrappers.h
+++ b/src/library/rendering/openglwrappers.h
@@ -94,6 +94,8 @@ OVERRIDE void glEnable(GLenum cap);
 void myglEnable(GLenum cap);
 OVERRIDE void glViewport(GLint x, GLint y, GLsizei width, GLsizei height);
 void myglViewport(GLint x, GLint y, GLsizei width, GLsizei height);
+OVERRIDE void glGetIntegerv(GLenum pname, GLint *data);
+void myglGetIntegerv(GLenum pname, GLint *data);
 
 // OVERRIDE void glDisable(GLenum cap);
 // void myglDisable(GLenum cap);


### PR DESCRIPTION
Unity 4.x uses GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX to determine if there is enough memory for a texture. However, llvmpipe is bugged and will return an uninitialized variable, i.e. non-deterministic. See https://gitlab.freedesktop.org/mesa/mesa/-/issues/14064