### PR TITLE
Add documentation about RNG sources

### DIFF
--- a/docs/guides/rng.md
+++ b/docs/guides/rng.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: RNG sources
+permalink: /rng/
+---
+
+This page list possible sources that games may use for their Random Number Generator (RNG), and which options control them in libTAS.
+
+* TOC
+{:toc}
+
+## Sources
+
+Besides of the [regular in-game sources of randomness](https://tasvideos.org/LuckManipulation), games may get data from other sources to update their PRNG. Some of these sources are configurable, while libTAS provides fixed values for others.
+
+For more information about these different sources, see [the Tech details page](how).
+
+### Configurable
+
+* System time: can be configured on the main window
+
+### Currently not configurable
+
+* reading `/proc/cputime`
+* using the current process pid
+* reading `/dev/urandom`

--- a/docs/help.md
+++ b/docs/help.md
@@ -12,3 +12,4 @@ get help from the [Discord server](https://discord.gg/3MBVAzU).
 * [Lua usage and functions](../guides/lua)
 * [Moviefile format](../guides/format)
 * [Tech details](../guides/how)
+* [Sources of randomness](../guides/rng)


### PR DESCRIPTION
After reading [the Tech details page](guides/how.md), I figured it would be helpful to have a document listing the different sources of RNG games may use. Hopefully I did not forget about any of them.

As a side-note, perhaps it would be useful to have options to modify each of them for luck manipulation? I wrote the document in a way that considers that may be the case in the future.