### PR TITLE
Initialize mouse event valuators to non-null dangling pointer

### DIFF
--- a/src/library/inputs/inputevents.cpp
+++ b/src/library/inputs/inputevents.cpp
@@ -754,6 +754,8 @@ static void generateMouseMotionEvents(void)
         dev->root_x = dev->event_x;
         dev->root_y = dev->event_y;
         dev->detail = 0;
+        dev->valuators.mask = reinterpret_cast<unsigned char *>(1); // Dangling but non-null pointer
+        dev->valuators.mask_len = 0;
         for (int d=0; d<GAMEDISPLAYNUM; d++) {
             if (x11::gameDisplays[d]) {
                 dev->root = DefaultRootWindow(x11::gameDisplays[d]);


### PR DESCRIPTION
Rust code using the [winit](https://github.com/rust-windowing/winit) library can crash when the rust stdlib is compiled with debug assertions, since winit turns the valuators into a slice which [must be non-null even for zero-sized slices](https://doc.rust-lang.org/stable/std/slice/fn.from_raw_parts.html#safety).

No idea if winit is well-founded in that assumption, but it doesn't hurt to do this here.

```
thread 'main' (110682) panicked at /home/jakob/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.12/src/platform_impl/linux/x11/event_processor.rs:1211:13:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
```