### PR TITLE
Fix building with `-Werror=format-security`

### DIFF
--- a/src/library/renderhud/FileDebug.cpp
+++ b/src/library/renderhud/FileDebug.cpp
@@ -135,7 +135,7 @@ void FileDebug::draw(uint64_t framecount, bool* p_open = nullptr)
 
                     for (fd_history_t fdh : fd_history[hovered_fd]) {
                         if ((frame >= fdh.first_frame) && (frame <= fdh.last_frame)) {
-                            ImGui::SetTooltip(fdh.file.c_str());
+                            ImGui::SetTooltip("%s", fdh.file.c_str());
                         }
                     }
                 }

--- a/src/library/renderhud/ProfilerDebug.cpp
+++ b/src/library/renderhud/ProfilerDebug.cpp
@@ -118,7 +118,7 @@ void ProfilerDebug::renderNode(int nodeId, const Profiler::Database* database, f
     {
         ImGui::Text("%s in %f ms", info.label.c_str(), lengthTimeMs);
         if (!info.description.empty())
-            ImGui::Text(info.description.c_str());
+            ImGui::Text("%s", info.description.c_str());
         ImGui::EndTooltip();
     }
     ImGui::PopStyleColor(3);


### PR DESCRIPTION
I was trying to build the [libtas-git](https://aur.archlinux.org/packages/libtas-git) AUR package, and it failed here since the arch build system enables `-Werror=format-security` by default:

```
CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
        -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
        -fstack-clash-protection -fcf-protection \
        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
```
