### PR TITLE
Bugfix following 121f4668

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -809,9 +809,9 @@ void GameLoop::processInputs(AllInputs &ai)
                 ai.clear();
 
                 /* Allow lua to modify inputs past the end of the movie */
-                Lua::Input::registerInputs(&ai, &modified);
+                Lua::Input::registerInputs(&ai, &modified_by_lua);
                 Lua::Callbacks::call(Lua::NamedLuaFunction::CallbackInput);
-                if (modified)
+                if (modified_by_lua)
                     movie.inputs->wasModified();
             }
 


### PR DESCRIPTION
Build crashes because some variables were overlooked during the rename in 121f4668