### PR TITLE
lua: add movie.getMovieFileName()

### DIFF
--- a/docs/guides/lua.md
+++ b/docs/guides/lua.md
@@ -298,6 +298,12 @@ Returns the current rerecord count of the movie, or -1 if no movie is loaded
 
 Returns 1 of the current frame is a draw frame, or 0 if not.
 
+#### movie.getMovieFileName
+
+    String movie.getMovieFileName()
+
+Returns the full name of the movie file (.ltm).
+
 ### Runtime functions
 
 Runtime functions must be performed in callback `onFrame()` to be effective on

--- a/src/program/lua/Movie.cpp
+++ b/src/program/lua/Movie.cpp
@@ -38,6 +38,7 @@ static const luaL_Reg movie_functions[] =
     { "time", Lua::Movie::time},
     { "rerecords", Lua::Movie::rerecords},
     { "isDraw", Lua::Movie::isDraw},
+    { "getMovieFileName", Lua::Movie::getMovieFileName},
     { NULL, NULL }
 };
 
@@ -88,5 +89,11 @@ int Lua::Movie::rerecords(lua_State *L)
 int Lua::Movie::isDraw(lua_State *L)
 {
     lua_pushinteger(L, static_cast<lua_Integer>(context->draw_frame));
+    return 1;
+}
+
+int Lua::Movie::getMovieFileName(lua_State *L)
+{
+    lua_pushstring(L, context->config.moviefile.c_str());
     return 1;
 }

--- a/src/program/lua/Movie.h
+++ b/src/program/lua/Movie.h
@@ -51,6 +51,9 @@ namespace Movie {
     /* Returns if the current frame is a draw frame */
     int isDraw(lua_State *L);
 
+    /* Get filename of the movie file (.ltm) */
+    int getMovieFileName(lua_State *L);
+
 }
 }
 


### PR DESCRIPTION
This patch adds a lua function to return the name of the ltm file

Why I need this: as I'm TASing a game with a lot of levels (500), I split the TAS into a ltm file for each individual level. In order to be able to perform some lua scripts (such as loading level data to display hitboxes etc.), I need to know in which level I am from the lua scripts. So far, I'm modifying the lua scripts manually every time. This patch spares me this manual step.