### PR TITLE
Fix annotations menu when loading movie file with --read CLI option

### DIFF
--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -653,7 +653,8 @@ void MainWindow::createMenus()
     movieMenu->addSeparator();
 
     annotateMovieAction = movieMenu->addAction(tr("Annotations..."), annotationsWindow, &AnnotationsWindow::show);
-    annotateMovieAction->setEnabled(false);
+    bool recording_inactive = ((context->config.sc.recording != SharedConfig::NO_RECORDING) && (gameLoop->movie.loadMovie() == 0));
+    annotateMovieAction->setEnabled(recording_inactive);
 
     movieMenu->addSeparator();
 


### PR DESCRIPTION
## Issue
When launching libTAS with the `--read` option to load a movie file (also probably with -w), the annotations menu is greyed out and it is not possible to edit them.

## Analysis
In `MainWindow.cpp`, `annotateMovieAction` is set to false by default, and only set to true in `slotMovieEnable()`, called when the user clicks on the checkbox. The case where the checkbox is on when libTAS starts (due to using -w or -r) is not taken into account.

## Solution
Instead of setting `annotateMovieAction` to false by default, we evaluate whether a movie is loaded to set its value. For this, I reused the logic used in `updateMovieParams()`.