### PR TITLE
Add shortcuts to toggle input editor options

### DIFF
--- a/src/program/ui/InputEditorWindow.cpp
+++ b/src/program/ui/InputEditorWindow.cpp
@@ -85,26 +85,26 @@ InputEditorWindow::InputEditorWindow(Context* c, MovieFile *movie, QWidget *pare
     QMenu* optionMenu = menuBar()->addMenu(tr("Options"));
     
     scrollingAct = optionMenu->addAction(tr("Disable autoscrolling"), this,
-        [=, this](bool checked){context->config.editor_autoscroll = !checked;});
+        [=, this](bool checked){context->config.editor_autoscroll = !checked;}, QKeySequence("Alt+D"));
     scrollingAct->setCheckable(true);
 
     rewindAct = optionMenu->addAction(tr("Rewind seeks to current frame"), this,
-        [=, this](bool checked){context->config.editor_rewind_seek = checked;});
+        [=, this](bool checked){context->config.editor_rewind_seek = checked;}, QKeySequence("Alt+R"));
 
     rewindAct->setCheckable(true);
 
     fastforwardAct = optionMenu->addAction(tr("Disable fastforward during rewind"), this,
-        [=, this](bool checked){context->config.editor_rewind_fastforward = !checked;});
+        [=, this](bool checked){context->config.editor_rewind_fastforward = !checked;}, QKeySequence("Alt+F"));
 
     fastforwardAct->setCheckable(true);
 
     markerPauseAct = optionMenu->addAction(tr("Autopause on markers"), this,
-        [=, this](bool checked){context->config.editor_marker_pause = checked;});
+        [=, this](bool checked){context->config.editor_marker_pause = checked;}, QKeySequence("Alt+A"));
 
     markerPauseAct->setCheckable(true);
 
     moveMarkerAct = optionMenu->addAction(tr("Move markers on frame addition or removal"), this,
-        [=, this](bool checked){context->config.editor_move_marker = checked;});
+        [=, this](bool checked){context->config.editor_move_marker = checked;}, QKeySequence("Alt+M"));
 
     moveMarkerAct->setCheckable(true);
 


### PR DESCRIPTION
As I toggle these options often (especially the first two ones), I find it convenient to have shortcuts to do so.

I used Alt+letter combinations as this seemed better to separate them from the shortcuts used to manipulate the movie. Feel free to challenge these!
