### PR TITLE
Bugfix: Author field was not properly updated when switching file

### DIFF
--- a/src/program/GameLoop.cpp
+++ b/src/program/GameLoop.cpp
@@ -232,16 +232,6 @@ void GameLoop::init()
          * or prepare a movie if in write mode.
          */
         if (context->config.sc.recording == SharedConfig::RECORDING_READ) {
-            int ret = movie.loadMovie();
-            if (ret < 0) {
-                emit alertToShow(MovieFile::errorString(ret));
-                context->config.sc.recording = SharedConfig::NO_RECORDING;
-            }
-            else {
-                /* Update the UI accordingly */
-                emit configChanged();
-            }
-
             /* Check md5 match */
             if ((!movie.header->md5_movie.empty()) && (context->md5_game.compare(movie.header->md5_movie) != 0))
                 emit alertToShow(QString("Game executable hash does not match with the hash stored in the movie!"));

--- a/src/program/GameLoop.h
+++ b/src/program/GameLoop.h
@@ -75,7 +75,6 @@ signals:
     void uiChanged();
     void newFrame();
     void statusChanged(int status);
-    void configChanged();
     void alertToShow(QString str);
     void sharedConfigChanged();
     void askToShow(QString str, void* promise);

--- a/src/program/ui/MainWindow.cpp
+++ b/src/program/ui/MainWindow.cpp
@@ -153,7 +153,6 @@ MainWindow::MainWindow(Context* c) : QMainWindow(), context(c)
     connect(gameLoop, &GameLoop::uiChanged, this, &MainWindow::updateUIFrequent);
     connect(gameLoop, &GameLoop::newFrame, this, &MainWindow::updateUIFrame, Qt::DirectConnection);
     connect(gameLoop, &GameLoop::statusChanged, this, &MainWindow::updateStatus);
-    connect(gameLoop, &GameLoop::configChanged, this, &MainWindow::updateUIFromConfig);
     connect(gameLoop, &GameLoop::alertToShow, this, &MainWindow::alertDialog);
     connect(gameLoop->gameEvents, &GameEvents::alertToShow, this, &MainWindow::alertDialog);
     connect(gameLoop, &GameLoop::sharedConfigChanged, this, &MainWindow::updateSharedConfigChanged);
@@ -1017,8 +1016,7 @@ void MainWindow::updateMovieParams()
     inputEditorWindow->resetInputs();
     movieFrameCount->setText(QString::number(context->config.sc.movie_framecount));
     rerecordCount->setText(QString::number(context->rerecord_count));
-    if (authorField->text().toStdString() == "")
-        authorField->setText(gameLoop->movie.header->authors.c_str());
+    authorField->setText(gameLoop->movie.header->authors.c_str());
     fpsNumField->setValue(context->config.sc.initial_framerate_num);
     fpsDenField->setValue(context->config.sc.initial_framerate_den);
     elapsedTimeSec->setValue(context->config.sc.initial_monotonic_time_sec);


### PR DESCRIPTION
## Issue

In a79444, I introduced a change to allow editing the authors field whatever the movie situation is. As the field got reverted to the movie's value upon game start, I introduced this check:
```
if (authorField->text().toStdString() == "")
    authorField->setText(gameLoop->movie.header->authors.c_str());
```
As a result, the field was not updated when a movie was loaded and we loaded another one (with different authors).

Removing this check was not sufficient as the author field kept being reverted back to the movie value. After a lot of debugging, I understood that this was due to `Gameloop::init()` propagating a `configChanged()` signal back to the main window, which reloads the movie in `updateMovieParams()` as a result, reverting any change we make to the field or to `gameLoop->movie.header->authors`.

 I'm not sure why there is any need to reload the movie at that point, since it's already loaded. I chose to remove that whole part of the code and signal, as tests show that it seems to work fine without it. Please review carefully, as I'm not entirely sure this has no consequences.

Another possibility to fix the issue could be to immediately save the movie everytime the authors field is changed, but that does not seem right from a UI perspective (I'm not expecting the movie to be saved if I did not save it).