### PR TITLE
Exit on unrecognized CLI option

### DIFF
--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
                 break;
             case '?':
                 std::cerr << "Unknown option character" << std::endl;
-                return -1;
+                return 1;
             case 'h':
                 print_usage();
                 return 0;
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
                 openInputEditor = true;
                 break;
             default:
-                return -1;
+                return 1;
         }
     }
 
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
     if (xcb_connection_has_error(context.conn))
     {
         std::cerr << "Cannot open display" << std::endl;
-        return -1;
+        return 1;
     }
 
     /* Open the xkb extension */
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
     catch (std::filesystem::filesystem_error const& ex) {
         std::cerr << "Cannot create dir " << context.config.configdir << std::endl;
         std::cerr << "what():  " << ex.what() << std::endl;
-        return -1;
+        return 1;
     }
 
     /* Now that we have the config dir, we load the game-specific config */

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
                 context.libtas32path = std::filesystem::weakly_canonical(optarg);
                 break;
             case '?':
-                std::cout << "Unknown option character" << std::endl;
+                std::cerr << "Unknown option character" << std::endl;
                 return -1;
             case 'h':
                 print_usage();

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
                 break;
             case '?':
                 std::cout << "Unknown option character" << std::endl;
-                break;
+                return -1;
             case 'h':
                 print_usage();
                 return 0;


### PR DESCRIPTION
When user enter an incorrect CLI parameter, a simple line is printed and libTAS is opened anyway, making it easy to miss the error.

Properly exit on incorrect parameter and write error on stderr instead of stdout