### PR TITLE
Input editor: improve UI by adding a button at the right of the table to add a new input column

### DIFF
--- a/src/program/ui/InputEditorView.cpp
+++ b/src/program/ui/InputEditorView.cpp
@@ -32,6 +32,7 @@
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QMessageBox>
+#include <QtWidgets/QPushButton>
 #include <QtGui/QClipboard>
 #include <QtGui/QGuiApplication>
 #include <QShortcut>
@@ -112,6 +113,12 @@ InputEditorView::InputEditorView(Context* c, MovieFile *m, QWidget *parent) : QT
 
     keyDialog = new KeyPressedDialog(c, this);
     keyDialog->withModifiers = false;
+
+    addColumnBtn = new QPushButton("+", horizontalHeader());
+    addColumnBtn->setFixedSize(20, horizontalHeader()->height());
+    addColumnBtn->move(horizontalHeader()->length(), 0);
+    addColumnBtn->show();
+    connect(addColumnBtn, &QPushButton::clicked, this, &InputEditorView::addInputColumn);
 
     inputEventWindow = new InputEventWindow(c, movie, this);
 
@@ -236,6 +243,14 @@ void InputEditorView::resizeAllColumns()
             int size = horizontalHeader()->sectionSize(c);
             horizontalHeader()->resizeSection(c, size + 2);
         }
+    }
+}
+
+void InputEditorView::resizeEvent(QResizeEvent* event)
+{
+    QTableView::resizeEvent(event);
+    if (addColumnBtn && horizontalHeader()) {
+        addColumnBtn->move(horizontalHeader()->length(), 0);
     }
 }
 

--- a/src/program/ui/InputEditorView.h
+++ b/src/program/ui/InputEditorView.h
@@ -22,6 +22,7 @@
 
 #include <QtWidgets/QTableView>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QPushButton>
 
 /* Forward declaration */
 struct Context;
@@ -91,6 +92,7 @@ protected:
     void timerEvent(QTimerEvent* event) override;
     void hideEvent(QHideEvent* event) override;
     void leaveEvent(QEvent *event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private slots:
     void resizeAllColumns();
@@ -138,6 +140,8 @@ private:
     QAction *lockAction;
     QAction *autoholdAction;
     QAction *autofireAction;
+
+    QPushButton *addColumnBtn = nullptr;
 
     bool autoScroll = true;
     int markerTimerId = 0;


### PR DESCRIPTION
## Motivation

In an effort to improve UI for new users, I had the idea of adding a button to add a new column at the right side of the table, to make it more intuitive.

## Change

The change introduces this "+" button on the right to add a new boolean input column: 
<img width="840" height="174" alt="plus_button" src="https://github.com/user-attachments/assets/d8d5c0a7-7dcc-4499-a6ac-7e268b752559" />

## Limitation

The "+" button is not considered for calculation of the window size. As a consequence, it cannot be reached with the horizontal scrollbar and will not be shown if the window is too small. I'm not familiar enough with Qt to find a solution to this. Also, I'm not what size is used to open the window by default as I'm using a tiling window manager (i3)