### PR TITLE
Fix game profile ini path being treated as a path segment

### DIFF
--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -29,7 +29,8 @@
 #include <filesystem>
 
 QString Config::iniPath(const std::filesystem::path& gamepath) const {
-    std::filesystem::path iniFile = configdir / gamepath.filename() / ".ini";
+    std::filesystem::path iniFile = configdir / gamepath.filename();
+    iniFile += ".ini";
     return QString(iniFile.c_str());
 }
 


### PR DESCRIPTION
I was debugging why I couldn't get Hollow Knight to run past frame 112. I bisected to https://github.com/clementgallet/libTAS/commit/919a40157be15ba510cd8b4a1b02cc6ddd4cbf5f, the issue was time tracking not being enabled due to the code loading the wrong ini path after the refactor to `std::filesystem`:

```diff
-  ~/.config/libTAS/Hollow Knight.ini
+  ~/.config/libTAS/Hollow Knight/.ini
```

There were also some `.ini` and `..ini` files reated in `.config`.