### PR TITLE
Fix SDL_TEXTINPUT ignoring Shift/Caps Lock for letter keys

### DIFF
--- a/src/library/inputs/inputevents.cpp
+++ b/src/library/inputs/inputevents.cpp
@@ -96,7 +96,18 @@ static void generateKeyEvent(int event_key, bool pressed)
                 event2.text.windowID = 1;
                 event2.text.timestamp = timestamp;
                 /* SDL keycode is identical to its char number for common chars */
-                event2.text.text[0] = static_cast<char>(event2.key.keysym.sym & 0xff);
+                {
+                    char c = static_cast<char>(event2.key.keysym.sym & 0xff);
+                    /* Apply Shift/Caps Lock to produce uppercase letters,
+                     * matching what a real OS input method would generate
+                     * for SDL_TEXTINPUT.  Without this, Shift+letter always
+                     * produces a lowercase TEXTINPUT character, breaking any
+                     * game that reads character input from SDL_TEXTINPUT
+                     * (e.g. ScummVM's SCI engine verb hotkeys). */
+                    if (c >= 'a' && c <= 'z' && (event2.key.keysym.mod & (sdl2::KMOD_SHIFT | sdl2::KMOD_CAPS)))
+                        c &= ~0x20;
+                    event2.text.text[0] = c;
+                }
                 event2.text.text[1] = '\0';
                 
                 sdlEventQueue.insert(&event2);


### PR DESCRIPTION
## Summary

`generateKeyEvent()` in `inputevents.cpp` generates `SDL_TEXTINPUT` events using the raw SDL keycode (`keysym.sym & 0xff`), which always produces lowercase for letter keys regardless of modifier state. Real SDL2 generates TEXTINPUT through the OS input method, which applies Shift/Caps Lock.

This breaks games that derive character input from `SDL_TEXTINPUT` rather than from `SDL_KEYDOWN` + modifier flags — for example, ScummVM's `obtainUnicode()` peeks the event queue for TEXTINPUT and uses it directly, bypassing its own Shift→uppercase fallback path.

## Fix

When `keysym.mod` has `KMOD_SHIFT` or `KMOD_CAPS` set, apply `c &= ~0x20` to letters a–z before writing the TEXTINPUT text. This matches real SDL2 behavior for ASCII letters.

Only letters are handled; non-letter shifted characters (e.g. Shift+1 → `!`) would require a keyboard layout lookup and are left for a future change.

## Relation to #405

Issue #405 (Shift+Click) was fixed by commits `5deef26` (mod field on SDL_KEYDOWN) and `422018a` (X11/XCB modifier state). Those fixes address modifier *flags* on key events — this PR addresses the *text content* of `SDL_TEXTINPUT` events, which is a separate code path that the earlier fixes don't reach.