### PR TITLE
Add libswresample6 as a dependency for the deb package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/clementgallet/libTAS
 
 Package: libtas
 Architecture: any
-Depends: libasound2 (>= 1.0.16) | libasound2t64, libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0) | libqt5core5t64, libqt5gui5 (>= 5.6.0) | libqt5gui5t64, libqt5widgets5 (>= 5.6.0) | libqt5widgets5t64, libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4 | libswresample5, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.4-0, ffmpeg, libcap2, binutils, file
+Depends: libasound2 (>= 1.0.16) | libasound2t64, libc6 (>= 2.15), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.7.0) | libqt5core5t64, libqt5gui5 (>= 5.6.0) | libqt5gui5t64, libqt5widgets5 (>= 5.6.0) | libqt5widgets5t64, libstdc++6 (>= 6), libswresample2 (>= 7:3.2.0) | libswresample3 | libswresample4 | libswresample5 | libswresample6, libx11-6, libxcb-keysyms1 (>= 0.4.0), libxcb-xkb1, libxcb1, libx11-xcb1, liblua5.4-0, ffmpeg, libcap2, binutils, file
 Description: A program to provide tool-assisted speedrun tools to Linux games


### PR DESCRIPTION
Support for libswresample6 was added in 75501656253d1357b802ce8227a43ea2126bc7bc. This adds it as a deb package dependency. This should enable users to install interim builds on Ubuntu 26.04.