### PR TITLE
Shutdown the Xlib ImGui backend when closing the OpenGL HUD

### DIFF
--- a/src/library/renderhud/RenderHUD_GL.cpp
+++ b/src/library/renderhud/RenderHUD_GL.cpp
@@ -26,6 +26,7 @@
 
 #include "../external/imgui/imgui.h"
 #include "../external/imgui/imgui_impl_opengl3.h"
+#include "../external/imgui/imgui_impl_xlib.h"
 
 namespace libtas {
 
@@ -35,6 +36,7 @@ RenderHUD_GL::~RenderHUD_GL() {
 
 void RenderHUD_GL::fini() {
     if (ImGui::GetCurrentContext()) {
+        ImGui_ImplXlib_Shutdown();
         ImGui_ImplOpenGL3_Shutdown();
         ImGui::DestroyContext();
     }


### PR DESCRIPTION
Title says it all! This caused a crash for me when I complete a recording. Which is harmless I think (?) but it triggered my OCD.

```
...
[00363] [imgui-error] (current settings: Assert=1, Log=1, Tooltip=1)
[00363] [imgui-error] In window 'Debug##Default': Forgot to shutdown Platform backend?
runner: ../../../src/library/../external/imgui/imgui.cpp:4467: void ImGui::Shutdown(): Assertion `(g.IO.BackendPlatformUserData == __null) && "Forgot to shutdown Platform backend?"' failed.
recv() returns 0 -> socket closed
The connection to the game was closed. Exiting
Aborted (core dumped)
Movie saved
```
This looks like some imgui thing did not get shutdown...

In the fini of RenderHUD_Vulkan.cpp ImGui_ImplXlib_Shutdown fn is called, so I mirrored that on the open GL side.
now src/library/renderhud/RenderHUD_GL.cpp matchs src/library/renderhud/RenderHUD_Vulkan.cpp

... and that seemed to fix it.

Also, I just want to say this is a wonderful app. so so so cool. great work!