### PR TITLE
Dockerfile: fix ruffle build, following upstream changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM debian:12 AS ruffle-builder
           pkg-config \
           libasound2-dev \
           libudev-dev \
+          libfontconfig-dev \
+          libssl-dev \
           default-jre-headless \
           g++ \
           curl


### PR DESCRIPTION
Ruffle build now crashes with openssl-related issue. Adding openssl-dev + other dependency now listed on [Ruffle readme](https://github.com/ruffle-rs/ruffle#linux-prerequisites).