### PR TITLE
Fix aarch64 build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,20 +16,21 @@ automake --add-missing
 mkdir -p build
 cd build
 CXXFLAGS="-O2 -g -Wall -pedantic" ../configure "$@"
-make -j4
+make -j$(nproc)
 
 # Build .AppImage
 
+ARCH=$(uname -m)
 if [ $SKIP_APPIMAGE -eq 0 ]; then
-    wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-    chmod +x linuxdeploy-x86_64.AppImage
-    wget -nc https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
-    chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
+    wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$ARCH.AppImage
+    chmod +x linuxdeploy-$ARCH.AppImage
+    wget -nc https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-$ARCH.AppImage
+    chmod +x linuxdeploy-plugin-qt-$ARCH.AppImage
 fi
 
 APPDIR_PATH=$(readlink -f ./AppDir)
 
 make prefix=/usr DESTDIR=$APPDIR_PATH install
 if [ $SKIP_APPIMAGE -eq 0 ]; then
-    ARCH=x86_64 ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir AppDir/ --plugin qt --output appimage
+    ./linuxdeploy-$ARCH.AppImage --appimage-extract-and-run --appdir AppDir/ --plugin qt --output appimage
 fi

--- a/src/library/checkpoint/clone_wrapper.h
+++ b/src/library/checkpoint/clone_wrapper.h
@@ -162,7 +162,7 @@
         "stp %5, %6, [x1]                \n"    \
         "mov x0, %1                      \n"    \
         "mov x2, %3                      \n"    \
-        "mov x3, %4                      \n"    \
+        "mov x4, %4                      \n"    \
         "mov x8, #220 /* __NR_clone */   \n"    \
         "svc #0                          \n"    \
                                                 \
@@ -183,7 +183,7 @@
           "r"(ptr_child_tid),                   \
           "r"(clone_restore_fn),                \
           "r"(thread_args)                      \
-        : "x0", "x1", "x2", "x3", "x8", "memory")
+        : "x0", "x1", "x2", "x4", "x8", "memory")
 
 /*
  * Based on sysdeps/unix/sysv/linux/aarch64/clone.S

--- a/src/library/checkpoint/clone_wrapper.h
+++ b/src/library/checkpoint/clone_wrapper.h
@@ -153,18 +153,17 @@
 #elif __aarch64__
 
 /* clang-format off */
-#define RUN_CLONE_RESTORE_FN(ret, clone_flags, new_sp, parent_tid,        \
-                 thread_args, clone_restore_fn)            \
+#define RUN_CLONE_RESTORE_FN(ret, clone_flags, new_sp, ptr_parent_tid, ptr_child_tid,   \
+                thread_args, clone_restore_fn)        \
     asm volatile(                              \
         "clone_emul:                     \n"    \
-        "ldr x1, %2                      \n"    \
         "and x1, x1, #~15                \n"    \
         "sub x1, x1, #16                 \n"    \
         "stp %5, %6, [x1]                \n"    \
         "mov x0, %1                      \n"    \
         "mov x2, %3                      \n"    \
         "mov x3, %4                      \n"    \
-        "mov x8, #220 /* __NR_clone */ \n"    \
+        "mov x8, #220 /* __NR_clone */   \n"    \
         "svc #0                          \n"    \
                                                 \
         "cbz x0, thread_run              \n"    \
@@ -179,11 +178,11 @@
         "clone_end:                      \n"    \
         : "=r"(ret)                             \
         : "r"(clone_flags),                     \
-          "m"(new_sp),                          \
-          "r"(&parent_tid),                     \
-          "r"(&thread_args[i].pid),             \
+          "r"(new_sp),                          \
+          "r"(ptr_parent_tid),                  \
+          "r"(ptr_child_tid),                   \
           "r"(clone_restore_fn),                \
-          "r"(&thread_args[i])                  \
+          "r"(thread_args)                      \
         : "x0", "x1", "x2", "x3", "x8", "memory")
 
 /*

--- a/src/library/hookpatch.cpp
+++ b/src/library/hookpatch.cpp
@@ -32,6 +32,7 @@
 #include <list>
 
 namespace libtas {
+#if defined(__i386__) || defined(__x86_64__)
 
 /* For jumping to any absolute address, we are using the following instruction: */
 # ifdef __i386__
@@ -46,7 +47,7 @@ static const unsigned char JMP_INSTR[] = {0xff, 0x25};
  *     aa bb cc dd ee ff gg hh   64-bit target address
  */
 
-// jmp *(%rip) 
+// jmp *(%rip)
 static const unsigned char JMP_INSTR[] = {0xff, 0x25, 0x00, 0x00, 0x00, 0x00};
 #define JMP_INSTR_LEN 14
 # endif
@@ -87,7 +88,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
 
     int operandSizeDouble = 4; // operand size for instructions that depend only on 16-bit prefix, and cannot be promoted by REX.W 64-bit
     int operandSize = 4; // operand size for instructions that depend on both operand-size prefixes
-    
+
     // Skip prefixes F0h, F2h, F3h, 66h, 67h, D8h-DFh, 2Eh, 36h, 3Eh, 26h, 64h and 65h
     while(*func == 0xF0 ||
           *func == 0xF2 ||
@@ -232,7 +233,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
     if (instr->has_modRM) {
         int modRM_mod = (instr->modRM & 0b11000000) >> 6;
         int modRM_rm = instr->modRM & 0b00000111;
-        
+
         // Process SIB
         instr->has_sib = false;
         if ((modRM_mod != 0b11) && (modRM_rm == 0b100))
@@ -244,7 +245,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
             // Skip displacement
             if ((modRM_mod == 0b00) && (sib_base == 0b101)) func += 4;   // Dword displacement with SIB
         }
-        
+
         if ((modRM_mod == 0b00) && (modRM_rm == 0b101)) func += 4;   // Dword displacement with base
         if  (modRM_mod == 0b01) func += 1;   // Byte displacement
         if  (modRM_mod == 0b10) func += 4;   // Dword displacement
@@ -281,8 +282,8 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
             case 0xB5: // MOV
             case 0xB6: // MOV
             case 0xB7: // MOV
-            case 0xC0: // 
-            case 0xC1: // 
+            case 0xC0: //
+            case 0xC1: //
             case 0xC6: // MOV
             case 0xCD: // INT
             case 0xD4: // AMX
@@ -323,13 +324,13 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
                 if ((instr->modRM & 0x30) == 0x00) // TEST
                     func += 1;
                 break;
-        
+
             // imm16
             case 0xC2: // RETN
             case 0xCA: // RETF
                 func += 2;   // RET
                 break;
-                
+
             // imm16/32
             case 0x05: // ADD
             case 0x0D: // OR
@@ -349,7 +350,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
             case 0xE9: // JMP
                 func += operandSizeDouble;
                 break;
-            
+
             // imm16/32/64
             case 0xB8: // MOV
             case 0xB9: // MOV
@@ -364,7 +365,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
             case 0xA3: // MOV
                 func += operandSize;
                 break;
-            
+
             case 0xF7:
                 if ((instr->modRM & 0x30) == 0x00) // TEST imm16/32
                     func += operandSizeDouble;
@@ -438,7 +439,7 @@ static int instruction_length(const unsigned char *func, instr_info *instr)
 /* To convert some instructions from the original function, we need to be at
  * 32-bit offset from the function location.
  * `current_tramp_segment` is the address of currently allocated segment, or null
- * `orig_fun` is the original function where we want to be at 32-bit max distance 
+ * `orig_fun` is the original function where we want to be at 32-bit max distance
  */
 static void* allocate_nearby_segment(void* current_tramp_segment, const void *orig_fun)
 {
@@ -455,7 +456,7 @@ static void* allocate_nearby_segment(void* current_tramp_segment, const void *or
     }
 
     /* If we arrive here, we need to allocate a segment */
-    
+
     /* Usually the lowest mapped address is 4096, given by vm.mmap_min_addr.
      * We use a much larger lowest value. */
     uintptr_t first_addr = 0x00100000;
@@ -463,7 +464,7 @@ static void* allocate_nearby_segment(void* current_tramp_segment, const void *or
         first_addr = (reinterpret_cast<uintptr_t>(orig_fun) - 0x70000000) & 0xFFFFFFFFFFFFF000;
 
     uintptr_t last_addr = reinterpret_cast<uintptr_t>(orig_fun) + 0x70000000;
-    
+
     /* Look for available segment by steps */
     void* obtained_addr = MAP_FAILED;
     for (uintptr_t addr = first_addr; addr < last_addr; addr += 0x00100000) {
@@ -471,12 +472,12 @@ static void* allocate_nearby_segment(void* current_tramp_segment, const void *or
         obtained_addr = mmap(reinterpret_cast<void*>(addr), Utils::getPageSize(), PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, 0, 0);
         if (obtained_addr != MAP_FAILED) break;
     }
-    
+
     if (obtained_addr == MAP_FAILED) {
         LOG(LL_WARN, LCF_HOOK, "  Could not obtain a memory segment for hookpatch functions, error %d", errno);
         return nullptr;
     }
-    
+
     return obtained_addr;
 }
 
@@ -493,21 +494,21 @@ struct jmp_info {
 static bool write_tramp_function(const void *orig_fun, void **pTramp)
 {
     static unsigned char* currentTrampAddr = nullptr;
-    
+
     currentTrampAddr = static_cast<unsigned char*>(allocate_nearby_segment(currentTrampAddr, orig_fun));
-    
+
     if (!currentTrampAddr) {
         *pTramp = nullptr;
         return false;
     }
-    
+
     *pTramp = currentTrampAddr;
-    
+
     const unsigned char* pOrig = static_cast<const unsigned char*>(orig_fun);
-    
+
     /* Overwrite the trampoline function */
     LOG(LL_DEBUG, LCF_HOOK, "  Building our trampoline function in %p", currentTrampAddr);
-    
+
     /* Write each instruction of the original function that we will overwrite,
      * and update instructions with relative addresses. Our trampoline function
      * is written in an address that is at most 32-bit away from the original
@@ -529,15 +530,15 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
      *     ad dr re ss to or ig fn   address to orig function offset by N bytes
      *     ad dr re ss to ju mp 01   address to orig called function 01
      */
-    
-    int cur_offset = 0;    
+
+    int cur_offset = 0;
     std::list<jmp_info> jmp_list;
     instr_info instr;
-    
+
     while (cur_offset < JMP_INSTR_LEN) {
         /* Transcribe each instruction, and update the occasionnal relative address */
         int instr_len = instruction_length(pOrig + cur_offset, &instr);
-        
+
         /* Print instruction */
         std::ostringstream oss_orig;
         for (int off = cur_offset; off < cur_offset + instr_len; off++) {
@@ -550,7 +551,7 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
         bool relative_rip = instr.has_modRM &&
             (instr.modRM & 0b11000000) == 0 &&
             (instr.modRM & 0b00000111) == 0b00000101;
-        
+
         // Case where instruction has a relative 32-bit operand
         bool relative_op =
             (!instr.multibyte_opcode && (
@@ -581,21 +582,21 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
             if (instr.operand_size_prefix)
                 LOG(LL_WARN, LCF_HOOK, "  Relative address is 16-bit, we do not support that!");
 
-            /* Compute where the relative adress is in the instruction. 
+            /* Compute where the relative adress is in the instruction.
              * There is no instruction that has a relative 64-bit address,
              * whatever prefix is present, so we don't need to check for that. */
             int off_to_rel = instr_len - 4;
-            
+
             LOG(LL_DEBUG, LCF_HOOK, "  Found instruction with rel addr %#x", (*reinterpret_cast<const int*>(pOrig+cur_offset+off_to_rel)));
-            
+
             /* Write the instruction and just change the offset to
             * the new offset between our function and the call target. */
             memcpy(currentTrampAddr, pOrig+cur_offset, off_to_rel);
             currentTrampAddr += off_to_rel;
-            
+
             const unsigned char* target_addr = pOrig + cur_offset + instr_len + (*reinterpret_cast<const int*>(pOrig+cur_offset+off_to_rel));
             LOG(LL_DEBUG, LCF_HOOK, "  Absolute addr becomes %p", target_addr);
-            
+
             ptrdiff_t new_offset = reinterpret_cast<ptrdiff_t>(target_addr) - reinterpret_cast<ptrdiff_t>(currentTrampAddr) - 4;
             /* Check if it fits into signed 32-bit */
             if (new_offset < INT32_MIN || new_offset > INT32_MAX) {
@@ -604,16 +605,16 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
                 return false;
             }
             int32_t new_offset_32 = static_cast<int32_t>(new_offset);
-            
+
             LOG(LL_DEBUG, LCF_HOOK, "  New relative addr becomes %#x", new_offset_32);
-            
+
             memcpy(currentTrampAddr, &new_offset_32, 4);
             currentTrampAddr += 4;
-            
+
             std::ostringstream oss_new;
             for (int i = 0; i < off_to_rel; i++) {
                 oss_new << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(*(pOrig+cur_offset+i)) << " ";
-            }                
+            }
             for (int i = 0; i < 4; i++) {
                 oss_new << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(*(currentTrampAddr-4+i)) << " ";
             }
@@ -621,7 +622,7 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
         }
         else if (relative_short) {
             LOG(LL_DEBUG, LCF_HOOK, "  Found conditional jump instruction %#hhx to rel addr %#hhx", *(pOrig+cur_offset), (*(pOrig+cur_offset+1)));
-            
+
             /* Compute where the relative adress is in the instruction. */
             int off_to_rel = instr_len - 1;
 
@@ -629,9 +630,9 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
             info.target_addr = pOrig + cur_offset + instr_len + (*reinterpret_cast<const int8_t*>(pOrig+cur_offset+off_to_rel));
             info.offset_addr = currentTrampAddr + off_to_rel;
             jmp_list.push_back(info);
-            
+
             LOG(LL_DEBUG, LCF_HOOK, "  Absolute addr becomes %p", info.target_addr);
-            
+
             /* Write the same conditional jump, but later change the offset
             * so that it jumps to another jump
             * instruction where we can write a 64-bit address. */
@@ -645,7 +646,7 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
         }
         cur_offset += instr_len;
     }
-    
+
     /* Write the jmp instruction to the orginal function */
     memcpy(currentTrampAddr, JMP_INSTR, sizeof(JMP_INSTR));
     currentTrampAddr += sizeof(JMP_INSTR);
@@ -669,7 +670,7 @@ static bool write_tramp_function(const void *orig_fun, void **pTramp)
         }
         int8_t off = static_cast<int8_t>(jump_offset);
         memcpy(info->offset_addr, &off, sizeof(int8_t));
-        
+
         /* Write JMP instruction */
         memcpy(currentTrampAddr, JMP_INSTR, sizeof(JMP_INSTR));
         currentTrampAddr += sizeof(JMP_INSTR);
@@ -718,11 +719,11 @@ void hook_patch(const char* name, const char* library, void** tramp_function, vo
 {
     const char* libpathstr = NULL;
     void* handle;
-    
+
     if (library) {
         /* Find the path to the library */
         std::string libpath = find_lib(library);
-        
+
         if (libpath.empty()) {
             LOG(LL_ERROR, LCF_HOOK, "Could not find %s path", library);
             return;
@@ -779,4 +780,13 @@ void hook_patch_addr(void *orig_fun, void** tramp_function, void* my_function)
     overwrite_orig_function(orig_fun, my_function);
 }
 
+#else
+void hook_patch(const char* name, const char* library, void** tramp_function, void* my_function)
+{
+}
+
+void hook_patch_addr(void *orig_fun, void** tramp_function, void* my_function)
+{
+}
+#endif
 }

--- a/src/library/wine/kernel32.cpp
+++ b/src/library/wine/kernel32.cpp
@@ -29,6 +29,7 @@
 #include <inttypes.h>
 
 namespace libtas {
+#if defined(__i386__) || defined(__x86_64__)
 
 typedef union _LARGE_INTEGER {
     struct {
@@ -124,5 +125,9 @@ void hook_kernel32()
     HOOK_PATCH_ORIG(QueryPerformanceCounter, "kernel32.dll.so");
 }
 
-
+#else
+void hook_kernel32()
+{
+}
+#endif
 }

--- a/src/library/wine/user32.cpp
+++ b/src/library/wine/user32.cpp
@@ -28,6 +28,7 @@
 #include "../shared/inputs/SingleInput.h"
 
 namespace libtas {
+#if defined(__i386__) || defined(__x86_64__)
 
 typedef struct tagPOINT {
     int32_t x;
@@ -123,5 +124,9 @@ void hook_user32()
     HOOK_PATCH_ORIG(GetAsyncKeyState, "user32.dll.so");
 }
 
-
+#else
+void hook_user32()
+{
+}
+#endif
 }

--- a/src/library/wine/wined3d.cpp
+++ b/src/library/wine/wined3d.cpp
@@ -26,6 +26,7 @@
 #include "global.h"
 
 namespace libtas {
+#if defined(__i386__) || defined(__x86_64__)
 
 namespace orig {
 
@@ -86,5 +87,9 @@ void hook_wined3d()
     }
 }
 
-
+#else
+void hook_wined3d()
+{
+}
+#endif
 }

--- a/src/library/wine/winehook.cpp
+++ b/src/library/wine/winehook.cpp
@@ -23,6 +23,7 @@
 #include "logging.h"
 
 namespace libtas {
+#if defined(__i386__) || defined(__x86_64__)
 
 struct winstring {
     unsigned short Length;
@@ -51,5 +52,9 @@ void hook_ntdll()
     HOOK_PATCH_ORIG(LdrGetProcedureAddress, "ntdll.dll.so");
 }
 
-
+#else
+void hook_ntdll()
+{
+}
+#endif
 }

--- a/src/program/Signature.cpp
+++ b/src/program/Signature.cpp
@@ -20,7 +20,9 @@
 #include "Signature.h"
 #include <sstream>
 #include <cstring>
+#if defined(__i386__) || defined(__x86_64__)
 #include <immintrin.h>
+#endif
 
 bool Signature::hasMask() const
 {
@@ -31,7 +33,7 @@ void Signature::fromIdaString(const std::string sigstr)
 {
     bytes.clear();
     mask.clear();
-    
+
     std::istringstream iss(sigstr);
     int next = iss.peek();
     while (next != EOF) {
@@ -100,6 +102,7 @@ static int memcmp_mask(const uint8_t *buffer1, const uint8_t *buffer2, const uin
 }
 
 // Find signature pattern in memory
+#if defined(__i386__) || defined(__x86_64__)
 __attribute__((target("avx2"))) uint8_t* SigSearch::FindAVX2(uint8_t* data, size_t size, const Signature &sig, bool hasWildcards)
 {
     const uint8_t *pat = sig.bytes.data();
@@ -169,6 +172,7 @@ __attribute__((target("avx2"))) uint8_t* SigSearch::FindAVX2(uint8_t* data, size
     // Search the last bytes without AVX2
     return SigSearch::FindCommon(data + i, size - i, sig, hasWildcards);
 }
+#endif
 
 
 // ------------------------------------------------------------------------------------------------
@@ -265,6 +269,7 @@ int SigSearch::SearchCommon(uint8_t* input, size_t inputLen, const Signature &si
 }
 
 // Fast AVX2 based search
+#if defined(__i386__) || defined(__x86_64__)
 int SigSearch::SearchAVX2(uint8_t* input, size_t inputLen, const Signature &sig, ptrdiff_t* output_offset)
 {
     size_t sigSize = sig.bytes.size();
@@ -292,17 +297,18 @@ int SigSearch::SearchAVX2(uint8_t* input, size_t inputLen, const Signature &sig,
 
     return count;
 }
+#endif
 
 // Search for signature pattern, returning a status result
 int SigSearch::Search(uint8_t* input, size_t inputLen, const Signature &sig, ptrdiff_t* output_offset)
 {
-#ifdef __arch64__
+#if defined(__i386__) || defined(__x86_64__)
+    static bool isAVX2Supported = __builtin_cpu_supports("avx2");
+#else
     /* AVX2 is for x86 arch, but a similar function could be written for aarch64 using SIMD:
      * <http://0x80.pl/notesen/2016-11-28-simd-strfind.html#aarch64-64-bit-code>
      */
     static bool isAVX2Supported = false;
-#else
-    static bool isAVX2Supported = __builtin_cpu_supports("avx2");
 #endif
     if (isAVX2Supported)
         return SearchAVX2(input, inputLen, sig, output_offset);

--- a/src/program/movie/InputSerialization.cpp
+++ b/src/program/movie/InputSerialization.cpp
@@ -77,7 +77,7 @@ int InputSerialization::writeFrame(std::ostream& stream, const AllInputs& inputs
         stream << '|' << std::endl;
         return 1;
     }
-    
+
     /* Write keyboard inputs */
     if (inputs.keyboard[0]) {
         stream.put('|');
@@ -145,7 +145,7 @@ int InputSerialization::writeFrame(std::ostream& stream, const AllInputs& inputs
             if (inputs.misc->flags & (1 << SingleInput::FLAG_CONTROLLER4_ADDED_REMOVED)) stream.put('4');
             if (inputs.misc->flags & (1 << SingleInput::FLAG_FOCUS_UNFOCUS)) stream.put('F');
         }
-        
+
         /* Write framerate inputs */
         /* Only store framerate if different from initial framerate */
         if ((inputs.misc->framerate_num && (inputs.misc->framerate_num != framerate_num)) ||
@@ -163,7 +163,7 @@ int InputSerialization::writeFrame(std::ostream& stream, const AllInputs& inputs
             else
             stream << framerate_den;
         }
-        
+
         /* Write realtime inputs */
         if (inputs.misc->realtime_sec) {
             stream.put('|');
@@ -184,7 +184,7 @@ int InputSerialization::readFrame(const std::string& line, AllInputs& inputs)
     int ret = 0;
 
     std::istringstream input_string(line);
-    char d;
+    signed char d;
     input_string >> d;
     if (d != '|')
         return -1;
@@ -246,7 +246,7 @@ int InputSerialization::readFrame(const std::string& line, AllInputs& inputs)
                 ret = readFramerateFrame(input_string, inputs);
                 if (ret < 0)
                     return ret;
-                
+
                 break;
         }
         if (ret < 0)
@@ -360,7 +360,7 @@ int InputSerialization::readFlagFrame(std::istringstream& input_string, AllInput
 {
     if (!inputs.misc)
         inputs.misc.reset(new MiscInputs{});
-    
+
     char d;
     input_string >> d;
     while (input_string && (d != '|')) {


### PR DESCRIPTION
Enough to get libTAS to a point where it builds and functions properly on aarch64 Linux systems (including savestates). Tested on aarch64 Fedora 44 and x86_64 Arch Linux. Closes #487. 