### PR TITLE
Fix int vs float args being used between SDL2 and SDL3 functions

### DIFF
--- a/src/library/inputs/sdlpointer.cpp
+++ b/src/library/inputs/sdlpointer.cpp
@@ -190,8 +190,15 @@ sdl3::SDL_MouseButtonFlags sdl3::SDL_GetRelativeMouseState(float *x, float *y)
     return SingleInput::toSDL3PointerMask(Inputs::game_ai.pointer.mask);
 }
 
-void SDL_WarpMouseInWindow(std::uintptr_t p1, std::uintptr_t p2, std::uintptr_t p3)
+void SDL_WarpMouseInWindow(std::uintptr_t p1, std::uintptr_t p2, std::uintptr_t p3, float f1, float f2)
 {
+#if defined(__x86_64__) || defined(__aarch64__)
+    if (get_sdlversion() == 3) {
+        memcpy(&p2, &f1, sizeof(float));
+        memcpy(&p3, &f2, sizeof(float));
+    }
+#endif
+
     const std::uintptr_t storage[] = {p1, p2, p3};
 
     invoke_sdl2_or_sdl3_from_storage(&sdl2::SDL_WarpMouseInWindow,
@@ -273,8 +280,15 @@ void sdl3::SDL_WarpMouseInWindow(SDL_Window *window, float fx, float fy)
     NATIVECALL(ORIG_SDL3_CALL(SDL_WarpMouseInWindow, (window, x, y)));
 }
 
-int SDL_WarpMouseGlobal(std::uintptr_t p1, std::uintptr_t p2)
+int SDL_WarpMouseGlobal(std::uintptr_t p1, std::uintptr_t p2, float f1, float f2)
 {
+#if defined(__x86_64__) || defined(__aarch64__)
+    if (get_sdlversion() == 3) {
+        memcpy(&p1, &f1, sizeof(float));
+        memcpy(&p2, &f2, sizeof(float));
+    }
+#endif
+
     const std::uintptr_t storage[] = {p1, p2};
 
     return invoke_sdl2_or_sdl3_from_storage(&sdl2::SDL_WarpMouseGlobal,

--- a/src/library/inputs/sdlpointer.h
+++ b/src/library/inputs/sdlpointer.h
@@ -228,7 +228,7 @@ Uint32 sdl2::SDL_GetRelativeMouseState(int *x, int *y);
  */
 sdl3::SDL_MouseButtonFlags sdl3::SDL_GetRelativeMouseState(float *x, float *y);
 
-OVERRIDE void SDL_WarpMouseInWindow(std::uintptr_t p1, std::uintptr_t p2, std::uintptr_t p3);
+OVERRIDE void SDL_WarpMouseInWindow(std::uintptr_t p1, std::uintptr_t p2, std::uintptr_t p3, float f1, float f2);
 
 /**
  *  \brief Moves the mouse to the given position within the window.
@@ -264,7 +264,7 @@ void sdl2::SDL_WarpMouseInWindow(SDL_Window * window, int x, int y);
  */
 void sdl3::SDL_WarpMouseInWindow(SDL_Window *window, float x, float y);
 
-OVERRIDE int SDL_WarpMouseGlobal(std::uintptr_t p1, std::uintptr_t p2);
+OVERRIDE int SDL_WarpMouseGlobal(std::uintptr_t p1, std::uintptr_t p2, float f1, float f2);
 
 /**
  *  \brief Moves the mouse to the given position in global screen space.


### PR DESCRIPTION
On x86_64 and aarch64, these are passed via different registers, so the uintptrs won't have the real args for floating point args