### PR TITLE
Add option to adjust font size for the OSD

### DIFF
--- a/src/library/renderhud/RenderHUD.cpp
+++ b/src/library/renderhud/RenderHUD.cpp
@@ -60,25 +60,25 @@ bool RenderHUD::init()
     if (!ImGui::GetCurrentContext()) {
         if (!XlibGameWindow::get())
             return false;
-        
+
         /* TODO: select one display? */
         for (int i=0; i<GAMEDISPLAYNUM; i++) {
             if (x11::gameDisplays[i]) {
                 ImGui::CreateContext();
                 ImPlot::CreateContext();
                 GlobalNative gn;
-                
+
                 ImGuiIO& io = ImGui::GetIO();
-                LuaDraw::LuaText::regular_font = io.Fonts->AddFontFromMemoryCompressedTTF(Roboto_compressed_data, Roboto_compressed_size, 16.0f);
-                LuaDraw::LuaText::monospace_font = io.Fonts->AddFontFromMemoryCompressedTTF(ProggyClean_compressed_data, ProggyClean_compressed_size, 16.0f);
+                LuaDraw::LuaText::regular_font = io.Fonts->AddFontFromMemoryCompressedTTF(Roboto_compressed_data, Roboto_compressed_size, Global::shared_config.osd_font_size);
+                LuaDraw::LuaText::monospace_font = io.Fonts->AddFontFromMemoryCompressedTTF(ProggyClean_compressed_data, ProggyClean_compressed_size, Global::shared_config.osd_font_size);
 
                 /* Disable config file */
                 io.IniFilename = NULL;
-                
+
                 ImGui_ImplXlib_Init(x11::gameDisplays[i], XlibGameWindow::get());
                 return true;
             }
-        }        
+        }
     }
     return false;
 }
@@ -131,11 +131,11 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
     static bool show_audio = false;
     static bool show_unity = false;
     static bool show_demo = false;
-    
+
     /* If encoding, we disable game detach feature for now */
     if (Global::shared_config.av_dumping)
         show_game_window = false;
-    
+
     int w = 0, h = 0;
     ScreenCapture::getDimensions(w, h);
 
@@ -147,25 +147,25 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
         /* Remove padding so that the texture is aligned with the window */
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
         ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_Once);
-        
+
         /* Enforce aspect ratio */
         float aspect_ratio = (float)w / (float)h;
         ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), aspectRatioCallback, (void*)&aspect_ratio);
         if (ImGui::Begin("Game window", &show_game_window, ImGuiWindowFlags_NoScrollbar)) {
             ImVec2 pos = ImGui::GetCursorScreenPos();
             ImVec2 avail_size = ImGui::GetContentRegionAvail();
-            
+
             game_window_x = pos.x;
             game_window_y = pos.y;
             game_window_scale = avail_size.x / static_cast<float>(w);
-            
+
             ImGui::GetWindowDrawList()->AddImage(
-                ImTextureRef(ScreenCapture::screenTexture()), 
-                ImVec2(game_window_x, game_window_y), 
-                ImVec2(game_window_x + avail_size.x, game_window_y + avail_size.y), 
-                ImVec2(0, invertedOrigin()?1:0), 
+                ImTextureRef(ScreenCapture::screenTexture()),
+                ImVec2(game_window_x, game_window_y),
+                ImVec2(game_window_x + avail_size.x, game_window_y + avail_size.y),
+                ImVec2(0, invertedOrigin()?1:0),
                 ImVec2(1, invertedOrigin()?0:1)
-            );                
+            );
 
             /* Show lua on top of the game window */
             if (show_lua)
@@ -179,7 +179,7 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
         game_window_x = 0.0f;
         game_window_y = 0.0f;
         game_window_scale = 1.0f;
-        
+
         /* Show lua in background */
         if (show_lua)
             LuaDraw::draw(ImGui::GetBackgroundDrawList(), ImVec2(0, 0), 1.0f);
@@ -188,7 +188,7 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
     if (Global::shared_config.osd) {
         ImGui::PushStyleColor(ImGuiCol_MenuBarBg, ImVec4(0.14f, 0.14f, 0.14f, 0.50f));
         ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.14f, 0.14f, 0.14f, 0.50f));
-        
+
         if (ImGui::BeginMainMenuBar()) {
             if (ImGui::BeginMenu("Display")) {
                 ImGui::MenuItem("Detach game window", nullptr, &show_game_window, supportsGameWindow());
@@ -210,7 +210,7 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
                 ImGui::MenuItem("Demo", nullptr, &show_demo);
                 ImGui::EndMenu();
             }
-            
+
             ImGui::Separator();
             float fps = FPSMonitor::tickRedraw();
             ImGui::Text("FPS: %2.1f", fps);
@@ -218,7 +218,7 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
         }
 		ImGui::PopStyleColor(2);
     }
-    
+
     if (supportsGameWindow()) {
         if (show_game_window && !old_show_game_window) {
             setWindowResizable(true);
@@ -236,16 +236,16 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
         }
     }
     old_show_game_window = show_game_window;
-    
+
     if (show_file)
         FileDebug::draw(framecount, &show_file);
-    
+
     if (show_framecount)
         FrameWindow::draw(framecount, nondraw_framecount, &show_framecount);
 
     if (show_inputs)
         InputsWindow::draw(ai, preview_ai, &show_inputs);
-        
+
     if (show_messages)
         MessageWindow::draw();
     else
@@ -256,7 +256,7 @@ void RenderHUD::drawAll(uint64_t framecount, uint64_t nondraw_framecount, const 
 
     if (show_crosshair)
         Crosshair::draw(ai);
-        
+
     if (show_log)
         LogWindow::draw(&show_log);
 
@@ -285,11 +285,11 @@ bool RenderHUD::doRender()
 {
     if (framesBeforeIdle > 0)
         return true;
-        
+
     /* Idling with 100ms steps between renders */
     static const TimeHolder stepTime{0, 100000000};
     static TimeHolder lastTime{}; // -> member, update on render
-    
+
     if (lastTime.tv_sec == 0) {
         lastTime = TimeHolder::now();
         return true;
@@ -310,14 +310,14 @@ void RenderHUD::setWindowResizable(bool resizable)
     for (int i=0; i<GAMEDISPLAYNUM; i++) {
         if (x11::gameDisplays[i]) {
             GlobalNative gn;
-            
+
             XSizeHints *xsh;
             xsh = XAllocSizeHints();
             xsh->flags = resizable ? PMinSize : PMinSize | PMaxSize;
 
             int w = 0, h = 0;
             ScreenCapture::getDimensions(w, h);
-            
+
             xsh->min_width = w;
             xsh->min_height = h;
 
@@ -325,7 +325,7 @@ void RenderHUD::setWindowResizable(bool resizable)
                 xsh->max_width = w;
                 xsh->max_height = h;
             }
-            
+
             XSetWMNormalHints(x11::gameDisplays[i], XlibGameWindow::get(), xsh);
             XFree(xsh);
             return;
@@ -338,18 +338,18 @@ bool RenderHUD::renderGameWindow()
 {
     if (!supportsGameWindow())
         return false;
-        
-    return show_game_window;    
+
+    return show_game_window;
 }
 
 void RenderHUD::scaleMouseInputs(MouseInputs* mi)
 {
     if (!Global::shared_config.mouse_support)
         return;
-        
+
     if (!show_game_window)
         return;
-    
+
     if (mi->mode == SingleInput::POINTER_MODE_ABSOLUTE) {
         mi->x = static_cast<int>((static_cast<float>(mi->x) - game_window_x) / game_window_scale);
         mi->y = static_cast<int>((static_cast<float>(mi->y) - game_window_y) / game_window_scale);

--- a/src/program/Config.cpp
+++ b/src/program/Config.cpp
@@ -60,6 +60,7 @@ bool Config::applyCliSetting(const std::string& key, const std::string& value)
     else if (key == "screen_height")            sc.screen_height = intValue;
     else if (key == "osd")                      sc.osd = boolValue;
     else if (key == "osd_encode")               sc.osd_encode = boolValue;
+    else if (key == "osd_font_size")            sc.osd_font_size = floatValue;
     else if (key == "prevent_savefiles")        sc.prevent_savefiles = boolValue;
     else if (key == "audio_bitdepth")           sc.audio_bitdepth = intValue;
     else if (key == "audio_channels")           sc.audio_channels = intValue;
@@ -113,7 +114,7 @@ void Config::save(const std::filesystem::path& gamepath) {
 
     /* Open the general preferences */
     std::filesystem::path generalPath = configdir / "libTAS.ini";
-    
+
     QSettings general_settings(QString(generalPath.c_str()), QSettings::IniFormat);
     general_settings.setFallbacksEnabled(false);
 
@@ -231,6 +232,7 @@ void Config::save(const std::filesystem::path& gamepath) {
     settings.setValue("screen_height", sc.screen_height);
     settings.setValue("osd", sc.osd);
     settings.setValue("osd_encode", sc.osd_encode);
+    settings.setValue("osd_font_size", sc.osd_font_size);
     settings.setValue("prevent_savefiles", sc.prevent_savefiles);
     settings.setValue("audio_bitdepth", sc.audio_bitdepth);
     settings.setValue("audio_channels", sc.audio_channels);
@@ -313,7 +315,7 @@ void Config::load(const std::filesystem::path& gamepath) {
 
     char *path;
     if (general_settings.contains("datadir")) {
-        datadir = general_settings.value("datadir").toString().toStdString();        
+        datadir = general_settings.value("datadir").toString().toStdString();
     }
     else {
         path = getenv("XDG_DATA_HOME");
@@ -458,6 +460,7 @@ void Config::load(const std::filesystem::path& gamepath) {
     sc.screen_height = settings.value("screen_height", sc.screen_height).toInt();
     sc.osd = settings.value("osd", sc.osd).toBool();
     sc.osd_encode = settings.value("osd_encode", sc.osd_encode).toBool();
+    sc.osd_font_size = settings.value("osd_font_size", sc.osd_font_size).toDouble();
     sc.prevent_savefiles = settings.value("prevent_savefiles", sc.prevent_savefiles).toBool();
     sc.audio_bitdepth = settings.value("audio_bitdepth", sc.audio_bitdepth).toInt();
     sc.audio_channels = settings.value("audio_channels", sc.audio_channels).toInt();

--- a/src/program/ui/settings/VideoPane.cpp
+++ b/src/program/ui/settings/VideoPane.cpp
@@ -27,15 +27,17 @@
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QGridLayout>
 #include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QFormLayout>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QRadioButton>
 #include <QtWidgets/QSpinBox>
+#include <QtWidgets/QDoubleSpinBox>
 
 VideoPane::VideoPane(Context* c) : context(c)
 {
     initLayout();
-    loadConfig();    
+    loadConfig();
     initSignals();
     initToolTips();
 }
@@ -82,15 +84,20 @@ void VideoPane::initLayout()
     screenLayout->addWidget(heightField, 2, 2);
 
     QGroupBox* osdBox = new QGroupBox(tr("On-screen display"));
-    QVBoxLayout* osdLayout = new QVBoxLayout;
+    QFormLayout* osdLayout = new QFormLayout;
     osdBox->setLayout(osdLayout);
+    osdLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
     osdMenuBox = new QCheckBox(tr("Main Menu"));
     osdEncodeBox = new QCheckBox(tr("OSD on video encode"));
 
-    osdLayout->addWidget(osdMenuBox);
-    osdLayout->addWidget(osdEncodeBox);
-    
+    osdLayout->addRow(osdMenuBox);
+    osdLayout->addRow(osdEncodeBox);
+
+    fontSize = new QDoubleSpinBox();
+    fontSize->setRange(0.1, 144.0);
+    osdLayout->addRow(new QLabel(tr("Font size:")), fontSize);
+
     renderingBox = new QGroupBox(tr("Rendering"));
     QVBoxLayout* renderingLayout = new QVBoxLayout;
     renderingBox->setLayout(renderingLayout);
@@ -138,6 +145,7 @@ void VideoPane::initSignals()
     });
     connect(osdMenuBox, &QAbstractButton::clicked, this, &VideoPane::saveConfig);
     connect(osdEncodeBox, &QAbstractButton::clicked, this, &VideoPane::saveConfig);
+    connect(fontSize, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &VideoPane::saveConfig);
 
     connect(rendSoftBox, &QAbstractButton::clicked, this, &VideoPane::saveConfig);
     connect(rendQualityChoice, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &VideoPane::saveConfig);
@@ -188,9 +196,11 @@ void VideoPane::loadConfig()
             screenCommonChoice->setCurrentIndex(index);
         }
     }
-    
+
     osdMenuBox->setChecked(context->config.sc.osd);
     osdEncodeBox->setChecked(context->config.sc.osd_encode);
+
+    fontSize->setValue(context->config.sc.osd_font_size);
 
     rendSoftBox->setChecked(context->config.sc.opengl_soft);
     rendQualityChoice->setCurrentIndex(rendQualityChoice->findData(context->config.sc.opengl_quality));
@@ -211,9 +221,11 @@ void VideoPane::saveConfig()
         context->config.sc.screen_width = widthField->value();
         context->config.sc.screen_height = heightField->value();
     }
-    
+
     context->config.sc.osd = osdMenuBox->isChecked();
     context->config.sc.osd_encode = osdEncodeBox->isChecked();
+
+    context->config.sc.osd_font_size = fontSize->value();
 
     context->config.sc.opengl_soft = rendSoftBox->isChecked();
     context->config.sc.opengl_quality = rendQualityChoice->itemData(rendQualityChoice->currentIndex()).toInt();

--- a/src/program/ui/settings/VideoPane.h
+++ b/src/program/ui/settings/VideoPane.h
@@ -27,6 +27,7 @@ class QComboBox;
 class QCheckBox;
 class QRadioButton;
 class QSpinBox;
+class QDoubleSpinBox;
 class ToolTipCheckBox;
 class ToolTipComboBox;
 class QGroupBox;
@@ -46,19 +47,20 @@ private:
     void initToolTips();
 
     void showEvent(QShowEvent *event) override;
-    
+
     QGroupBox* screenBox;
     QGroupBox* renderingBox;
-    
+
     QRadioButton* screenNativeRadio;
     QRadioButton* screenCommonRadio;
     QRadioButton* screenCustomRadio;
     QComboBox* screenCommonChoice;
     QSpinBox* widthField;
     QSpinBox* heightField;
-    
+
     QCheckBox* osdMenuBox;
     QCheckBox* osdEncodeBox;
+    QDoubleSpinBox* fontSize;
 
     ToolTipCheckBox* rendSoftBox;
     ToolTipComboBox* rendQualityChoice;

--- a/src/shared/SharedConfig.h
+++ b/src/shared/SharedConfig.h
@@ -232,7 +232,7 @@ struct __attribute__((packed, aligned(8))) SharedConfig {
         SLEEP_MAIN,
         SLEEP_ALWAYS,
     };
-    
+
     /* How are we handling sleeps */
     int sleep_handling = SLEEP_MAIN;
 
@@ -298,6 +298,9 @@ struct __attribute__((packed, aligned(8))) SharedConfig {
 
     /* Display OSD in the video encode */
     bool osd_encode = false;
+
+    /* Font size for OSD */
+    double osd_font_size = 16.0;
 
     /* Use a backup of savefiles in memory, which leaves the original
      * savefiles unmodified and save the content in savestates */


### PR DESCRIPTION
This is useful for HIDPI displays and/or video encodes where the OSD is included. The `osd_font_size` config option can be used to adjust this.

In Settings --> Video:
<img width="860" height="1248" alt="Screenshot from 2026-09-03 16-16-59" src="https://github.com/user-attachments/assets/95a721e9-af50-4bfb-8a99-fbec8cc700f1" />

In-game:
<img width="1281" height="801" alt="Screenshot from 2026-09-03 16-18-35" src="https://github.com/user-attachments/assets/eac6330e-04e6-46ba-b916-2c7934c6fed9" />
